### PR TITLE
feat: complete Phase 1 foundations (state, persistence, API, TTS, overlay)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,5 +3,6 @@ LLM_MODEL=deepseek/deepseek-chat-v3-0324:free
 PORT=3001
 API_HOST_PORT=3001
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/improv_court
+TTS_PROVIDER=noop
 VERDICT_VOTE_WINDOW_MS=20000
 SENTENCE_VOTE_WINDOW_MS=20000

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,64 @@
+# Load environment values when .env exists
+ifneq (,$(wildcard ./.env))
+include .env
+export
+endif
+
+SHELL := /usr/bin/env bash
+.DEFAULT_GOAL := help
+
+NPM ?= npm
+DOCKER_COMPOSE ?= docker compose
+
+.PHONY: help install dev lint build test test-spec ci start migrate migrate-dist docker-up docker-down docker-restart clean status
+
+help: ## Show available commands
+	@awk 'BEGIN {FS = ":.*##"; printf "\nImprov Court Make targets:\n\n"} /^[a-zA-Z0-9_.-]+:.*##/ { printf "  %-18s %s\n", $$1, $$2 } END { printf "\n" }' $(MAKEFILE_LIST)
+
+install: ## Install Node dependencies
+	$(NPM) install
+
+dev: ## Start local dev server with watch mode
+	$(NPM) run dev
+
+lint: ## Run TypeScript type-check (no emit)
+	$(NPM) run lint
+
+build: ## Compile TypeScript to dist/
+	$(NPM) run build
+
+test: ## Run test suite
+	$(NPM) test
+
+test-spec: ## Run tests with spec reporter
+	$(NPM) test -- --test-reporter=spec
+
+ci: ## Run local CI parity checks (lint + build + test)
+	$(MAKE) lint
+	$(MAKE) build
+	$(MAKE) test
+
+start: ## Run compiled app from dist/
+	$(NPM) run start
+
+migrate: ## Run database migrations in source mode (tsx)
+	$(NPM) run migrate
+
+migrate-dist: ## Run database migrations in compiled mode
+	$(NPM) run migrate:dist
+
+docker-up: ## Start API + Postgres with docker compose
+	$(NPM) run docker:up
+
+docker-down: ## Stop docker compose services
+	$(NPM) run docker:down
+
+docker-restart: ## Restart docker compose stack
+	$(MAKE) docker-down
+	$(MAKE) docker-up
+
+clean: ## Remove generated build artifacts
+	rm -rf dist
+
+status: ## Show concise git status
+	git status --short

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ It does **not** depend on `subcult-corp` at runtime.
 
 ## Documentation
 
-| Document | Description |
-|---|---|
+| Document                                                                               | Description                                                                            |
+| -------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
 | [docs/ADR-001-improv-court-architecture.md](docs/ADR-001-improv-court-architecture.md) | Architecture Decision Record: runtime boundaries, data contracts, and phase invariants |
-| [docs/architecture.md](docs/architecture.md) | System architecture, agent roles, and phase flow |
-| [docs/api.md](docs/api.md) | REST API endpoints, schemas, and SSE event contracts |
-| [docs/operator-runbook.md](docs/operator-runbook.md) | Setup, configuration, deployment, and monitoring |
-| [docs/moderation-playbook.md](docs/moderation-playbook.md) | Content moderation system and incident procedures |
-| [docs/event-taxonomy.md](docs/event-taxonomy.md) | Canonical event taxonomy, payload schemas, and logging guidelines |
+| [docs/architecture.md](docs/architecture.md)                                           | System architecture, agent roles, and phase flow                                       |
+| [docs/api.md](docs/api.md)                                                             | REST API endpoints, schemas, and SSE event contracts                                   |
+| [docs/operator-runbook.md](docs/operator-runbook.md)                                   | Setup, configuration, deployment, and monitoring                                       |
+| [docs/moderation-playbook.md](docs/moderation-playbook.md)                             | Content moderation system and incident procedures                                      |
+| [docs/event-taxonomy.md](docs/event-taxonomy.md)                                       | Canonical event taxonomy, payload schemas, and logging guidelines                      |
 
 ## What is implemented
 
@@ -31,9 +31,9 @@ It does **not** depend on `subcult-corp` at runtime.
 - Jury verdict and sentence voting endpoints
 - Deterministic phase-order and vote-window enforcement
 - Minimal stripped web UI (`public/index.html`)
-  - Overlay shell with phase timer, active speaker, and live captions
-  - Verdict/sentence poll bars with live percentages and phase-gated voting
-  - SSE analytics events for poll start/close and vote completion
+    - Overlay shell with phase timer, active speaker, and live captions
+    - Verdict/sentence poll bars with live percentages and phase-gated voting
+    - SSE analytics events for poll start/close and vote completion
 
 ## Environment
 
@@ -45,6 +45,7 @@ Key variables:
 - `LLM_MODEL`
 - `PORT`
 - `DATABASE_URL` (Postgres connection string for durable persistence)
+- `TTS_PROVIDER` (`noop` or `mock`; defaults to `noop`)
 - `VERDICT_VOTE_WINDOW_MS`
 - `SENTENCE_VOTE_WINDOW_MS`
 
@@ -52,6 +53,8 @@ If `OPENROUTER_API_KEY` is empty, the app falls back to deterministic mock dialo
 
 If `DATABASE_URL` is set, the app uses Postgres-backed persistence and runs migrations at startup.
 If `DATABASE_URL` is missing, the app falls back to in-memory storage (non-durable).
+
+`TTS_PROVIDER=noop` keeps TTS silent (default). `TTS_PROVIDER=mock` records adapter calls for local/testing workflows without requiring an external speech provider.
 
 ## Run
 

--- a/docs/event-taxonomy.md
+++ b/docs/event-taxonomy.md
@@ -11,16 +11,16 @@ to any in-process `store.subscribe()` listener.
 
 All events share the following envelope fields:
 
-| Field       | Type     | Description |
-|-------------|----------|-------------|
-| `id`        | `string` | UUID auto-generated per event |
-| `sessionId` | `string` | Correlation ID: identifies the court session |
-| `type`      | `string` | Event type name (see below) |
+| Field       | Type     | Description                                    |
+| ----------- | -------- | ---------------------------------------------- |
+| `id`        | `string` | UUID auto-generated per event                  |
+| `sessionId` | `string` | Correlation ID: identifies the court session   |
+| `type`      | `string` | Event type name (see below)                    |
 | `at`        | `string` | ISO 8601 timestamp when the event was produced |
-| `payload`   | `object` | Type-specific data (see individual schemas) |
+| `payload`   | `object` | Type-specific data (see individual schemas)    |
 
 > **Correlation IDs** — use `sessionId` to correlate events across a session
-> lifecycle.  Within a payload, `turnId` correlates events to a specific
+> lifecycle. Within a payload, `turnId` correlates events to a specific
 > dialogue turn, and `phase` correlates events to the current court phase.
 > A future `request_id` field (HTTP-layer) can be joined to session events via
 > `sessionId` when the session is created from a POST request.
@@ -29,7 +29,7 @@ All events share the following envelope fields:
 
 ## Phase sequence
 
-Phases advance in strict forward order.  Skipping `evidence_reveal` (going
+Phases advance in strict forward order. Skipping `evidence_reveal` (going
 directly from `witness_exam` to `closings`) is the only permitted skip.
 
 ```
@@ -39,19 +39,19 @@ case_prompt → openings → witness_exam → [evidence_reveal →] closings
 
 ### Phase-transition checklist
 
-Every phase transition emits a `phase_changed` event.  The table below
+Every phase transition emits a `phase_changed` event. The table below
 confirms that each transition has a matching event name:
 
-| Transition                            | Event emitted   |
-|---------------------------------------|-----------------|
-| `case_prompt` → `openings`            | `phase_changed` |
-| `openings` → `witness_exam`           | `phase_changed` |
-| `witness_exam` → `evidence_reveal`    | `phase_changed` |
-| `witness_exam` → `closings` (skip)    | `phase_changed` |
-| `evidence_reveal` → `closings`        | `phase_changed` |
-| `closings` → `verdict_vote`           | `phase_changed` + `analytics_event` (`poll_started`) |
-| `verdict_vote` → `sentence_vote`      | `phase_changed` + `analytics_event` (`poll_closed`) + `analytics_event` (`poll_started`) |
-| `sentence_vote` → `final_ruling`      | `phase_changed` + `analytics_event` (`poll_closed`) |
+| Transition                         | Event emitted                                                                                            |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `case_prompt` → `openings`         | `phase_changed`                                                                                          |
+| `openings` → `witness_exam`        | `phase_changed`                                                                                          |
+| `witness_exam` → `evidence_reveal` | `phase_changed`                                                                                          |
+| `witness_exam` → `closings` (skip) | `phase_changed`                                                                                          |
+| `evidence_reveal` → `closings`     | `phase_changed`                                                                                          |
+| `closings` → `verdict_vote`        | `phase_changed` + `analytics_event` (`poll_started`)                                                     |
+| `verdict_vote` → `sentence_vote`   | `phase_changed` + `vote_closed` + `analytics_event` (`poll_closed`) + `analytics_event` (`poll_started`) |
+| `sentence_vote` → `final_ruling`   | `phase_changed` + `vote_closed` + `analytics_event` (`poll_closed`)                                      |
 
 ---
 
@@ -67,7 +67,7 @@ Emitted when a new session record is inserted.
 
 ```ts
 {
-  sessionId: string; // UUID of the newly created session
+    sessionId: string; // UUID of the newly created session
 }
 ```
 
@@ -75,13 +75,13 @@ Emitted when a new session record is inserted.
 
 ```json
 {
-  "id": "e1a2b3c4-…",
-  "sessionId": "f5d6e7f8-…",
-  "type": "session_created",
-  "at": "2024-01-15T10:00:00.000Z",
-  "payload": {
-    "sessionId": "f5d6e7f8-…"
-  }
+    "id": "e1a2b3c4-…",
+    "sessionId": "f5d6e7f8-…",
+    "type": "session_created",
+    "at": "2024-01-15T10:00:00.000Z",
+    "payload": {
+        "sessionId": "f5d6e7f8-…"
+    }
 }
 ```
 
@@ -97,8 +97,8 @@ Emitted when the orchestrator begins processing the session.
 
 ```ts
 {
-  sessionId: string;
-  startedAt: string; // ISO 8601
+    sessionId: string;
+    startedAt: string; // ISO 8601
 }
 ```
 
@@ -106,11 +106,11 @@ Emitted when the orchestrator begins processing the session.
 
 ```json
 {
-  "type": "session_started",
-  "payload": {
-    "sessionId": "f5d6e7f8-…",
-    "startedAt": "2024-01-15T10:00:01.000Z"
-  }
+    "type": "session_started",
+    "payload": {
+        "sessionId": "f5d6e7f8-…",
+        "startedAt": "2024-01-15T10:00:01.000Z"
+    }
 }
 ```
 
@@ -136,12 +136,12 @@ Emitted every time the session advances to a new phase.
 
 ```json
 {
-  "type": "phase_changed",
-  "payload": {
-    "phase": "verdict_vote",
-    "phaseStartedAt": "2024-01-15T10:04:30.000Z",
-    "phaseDurationMs": 20000
-  }
+    "type": "phase_changed",
+    "payload": {
+        "phase": "verdict_vote",
+        "phaseStartedAt": "2024-01-15T10:04:30.000Z",
+        "phaseDurationMs": 20000
+    }
 }
 ```
 
@@ -157,22 +157,22 @@ Emitted whenever a new dialogue turn is stored.
 
 ```ts
 {
-  turn: {
-    id: string;           // UUID — use as turnId for correlation
-    sessionId: string;
-    turnNumber: number;
-    speaker: AgentId;
-    role: CourtRole;
-    phase: CourtPhase;    // phase in which the turn was generated
-    dialogue: string;
-    createdAt: string;    // ISO 8601
-  };
+    turn: {
+        id: string; // UUID — use as turnId for correlation
+        sessionId: string;
+        turnNumber: number;
+        speaker: AgentId;
+        role: CourtRole;
+        phase: CourtPhase; // phase in which the turn was generated
+        dialogue: string;
+        createdAt: string; // ISO 8601
+    }
 }
 ```
 
 **PII / safety note** — `dialogue` is LLM-generated text that has passed through
-the content filter.  Flagged content is replaced with a redaction placeholder
-before this event is emitted.  `dialogue` must never be logged at `debug` level
+the content filter. Flagged content is replaced with a redaction placeholder
+before this event is emitted. `dialogue` must never be logged at `debug` level
 or below in production environments.
 
 ---
@@ -187,10 +187,10 @@ Emitted after a jury vote is successfully recorded.
 
 ```ts
 {
-  voteType: 'verdict' | 'sentence';
-  choice: string;
-  verdictVotes:  Record<string, number>; // cumulative totals
-  sentenceVotes: Record<string, number>;
+    voteType: 'verdict' | 'sentence';
+    choice: string;
+    verdictVotes: Record<string, number>; // cumulative totals
+    sentenceVotes: Record<string, number>;
 }
 ```
 
@@ -198,13 +198,47 @@ Emitted after a jury vote is successfully recorded.
 
 ```json
 {
-  "type": "vote_updated",
-  "payload": {
-    "voteType": "verdict",
-    "choice": "guilty",
-    "verdictVotes": { "guilty": 7, "not_guilty": 2 },
-    "sentenceVotes": {}
-  }
+    "type": "vote_updated",
+    "payload": {
+        "voteType": "verdict",
+        "choice": "guilty",
+        "verdictVotes": { "guilty": 7, "not_guilty": 2 },
+        "sentenceVotes": {}
+    }
+}
+```
+
+---
+
+### `vote_closed`
+
+Emitted once when a vote phase closes (i.e., when transitioning away from
+`verdict_vote` or `sentence_vote`).
+
+**Severity:** `info`
+
+**Payload**
+
+```ts
+{
+    pollType: 'verdict' | 'sentence';
+    closedAt: string; // ISO 8601
+    votes: Record<string, number>; // snapshot of tallies at close
+    nextPhase: CourtPhase; // phase entered after close
+}
+```
+
+**Example**
+
+```json
+{
+    "type": "vote_closed",
+    "payload": {
+        "pollType": "verdict",
+        "closedAt": "2024-01-15T10:05:00.000Z",
+        "votes": { "guilty": 7, "not_guilty": 2 },
+        "nextPhase": "sentence_vote"
+    }
 }
 ```
 
@@ -212,13 +246,13 @@ Emitted after a jury vote is successfully recorded.
 
 ### `analytics_event`
 
-Poll lifecycle signals.  Three named sub-events are emitted under this type:
+Poll lifecycle signals. Three named sub-events are emitted under this type:
 
-| `name`           | When                                              |
-|------------------|---------------------------------------------------|
+| `name`           | When                                                     |
+| ---------------- | -------------------------------------------------------- |
 | `poll_started`   | Phase transitions into `verdict_vote` or `sentence_vote` |
-| `vote_completed` | A vote is successfully cast                       |
-| `poll_closed`    | Phase transitions away from a vote phase          |
+| `vote_completed` | A vote is successfully cast                              |
+| `poll_closed`    | Phase transitions away from a vote phase                 |
 
 **Severity:** `info`
 
@@ -237,12 +271,12 @@ Poll lifecycle signals.  Three named sub-events are emitted under this type:
 
 ```json
 {
-  "type": "analytics_event",
-  "payload": {
-    "name": "poll_started",
-    "pollType": "verdict",
-    "phase": "verdict_vote"
-  }
+    "type": "analytics_event",
+    "payload": {
+        "name": "poll_started",
+        "pollType": "verdict",
+        "phase": "verdict_vote"
+    }
 }
 ```
 
@@ -250,12 +284,12 @@ Poll lifecycle signals.  Three named sub-events are emitted under this type:
 
 ```json
 {
-  "type": "analytics_event",
-  "payload": {
-    "name": "vote_completed",
-    "pollType": "verdict",
-    "choice": "guilty"
-  }
+    "type": "analytics_event",
+    "payload": {
+        "name": "vote_completed",
+        "pollType": "verdict",
+        "choice": "guilty"
+    }
 }
 ```
 
@@ -263,12 +297,12 @@ Poll lifecycle signals.  Three named sub-events are emitted under this type:
 
 ```json
 {
-  "type": "analytics_event",
-  "payload": {
-    "name": "poll_closed",
-    "pollType": "verdict",
-    "phase": "sentence_vote"
-  }
+    "type": "analytics_event",
+    "payload": {
+        "name": "poll_closed",
+        "pollType": "verdict",
+        "phase": "sentence_vote"
+    }
 }
 ```
 
@@ -292,20 +326,20 @@ Emitted when a turn's content is flagged and redacted by the content filter.
 ```
 
 **PII / safety note** — this event must **not** include the original
-(pre-redaction) dialogue.  Log `reasons` and `turnId` only; do not log
+(pre-redaction) dialogue. Log `reasons` and `turnId` only; do not log
 `speaker` names at `error` severity.
 
 **Example**
 
 ```json
 {
-  "type": "moderation_action",
-  "payload": {
-    "turnId": "a1b2c3d4-…",
-    "speaker": "mux",
-    "reasons": ["hate_speech"],
-    "phase": "openings"
-  }
+    "type": "moderation_action",
+    "payload": {
+        "turnId": "a1b2c3d4-…",
+        "speaker": "mux",
+        "reasons": ["hate_speech"],
+        "phase": "openings"
+    }
 }
 ```
 
@@ -321,24 +355,24 @@ Emitted when a vote is rejected due to the per-IP rate limit.
 
 ```ts
 {
-  ip: string;                          // the source IP address
-  voteType: 'verdict' | 'sentence';
+    ip: string; // the source IP address
+    voteType: 'verdict' | 'sentence';
 }
 ```
 
 **PII / safety note** — `ip` is operational data used for abuse detection only.
-It must **not** be stored in long-term analytics storage.  Redact or omit `ip`
+It must **not** be stored in long-term analytics storage. Redact or omit `ip`
 when forwarding these events to external logging pipelines.
 
 **Example**
 
 ```json
 {
-  "type": "vote_spam_blocked",
-  "payload": {
-    "ip": "203.0.113.42",
-    "voteType": "verdict"
-  }
+    "type": "vote_spam_blocked",
+    "payload": {
+        "ip": "203.0.113.42",
+        "voteType": "verdict"
+    }
 }
 ```
 
@@ -354,8 +388,8 @@ Emitted when the session reaches `final_ruling` successfully.
 
 ```ts
 {
-  sessionId: string;
-  completedAt: string; // ISO 8601
+    sessionId: string;
+    completedAt: string; // ISO 8601
 }
 ```
 
@@ -371,9 +405,9 @@ Emitted when the orchestrator throws an unrecoverable error.
 
 ```ts
 {
-  sessionId: string;
-  reason: string;      // error message (sanitized)
-  completedAt: string; // ISO 8601
+    sessionId: string;
+    reason: string; // error message (sanitized)
+    completedAt: string; // ISO 8601
 }
 ```
 
@@ -381,12 +415,12 @@ Emitted when the orchestrator throws an unrecoverable error.
 
 ```json
 {
-  "type": "session_failed",
-  "payload": {
-    "sessionId": "f5d6e7f8-…",
-    "reason": "LLM request timed out after 30 s",
-    "completedAt": "2024-01-15T10:09:00.000Z"
-  }
+    "type": "session_failed",
+    "payload": {
+        "sessionId": "f5d6e7f8-…",
+        "reason": "LLM request timed out after 30 s",
+        "completedAt": "2024-01-15T10:09:00.000Z"
+    }
 }
 ```
 
@@ -394,23 +428,23 @@ Emitted when the orchestrator throws an unrecoverable error.
 
 ## Severity levels
 
-| Severity | Event types |
-|----------|-------------|
-| `info`   | `session_created`, `session_started`, `phase_changed`, `turn`, `vote_updated`, `analytics_event`, `session_completed` |
-| `warn`   | `moderation_action`, `vote_spam_blocked` |
-| `error`  | `session_failed` |
+| Severity | Event types                                                                                                                          |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `info`   | `session_created`, `session_started`, `phase_changed`, `turn`, `vote_updated`, `vote_closed`, `analytics_event`, `session_completed` |
+| `warn`   | `moderation_action`, `vote_spam_blocked`                                                                                             |
+| `error`  | `session_failed`                                                                                                                     |
 
 ---
 
 ## Logging guidelines
 
 1. **PII constraints** — dialogue text (`turn.dialogue`) must never appear in
-   log lines at `debug` or below in production.  The content filter guarantees
+   log lines at `debug` or below in production. The content filter guarantees
    it is redacted before the `turn` event is emitted, but downstream log
    aggregators must treat the field as sensitive.
 
 2. **IP addresses** — the `ip` field in `vote_spam_blocked` is operational
-   data only.  Do not forward it to long-term analytics stores.
+   data only. Do not forward it to long-term analytics stores.
 
 3. **Redaction in `moderation_action`** — log only `turnId` and `reasons`;
    do not re-log the original dialogue.
@@ -428,13 +462,13 @@ Emitted when the orchestrator throws an unrecoverable error.
 
 [`src/events.ts`](../src/events.ts) exports `assertEventPayload(event)`, a
 runtime shape guard that throws a `TypeError` when a required field is missing
-or has the wrong type.  Call it on any `CourtEvent` before forwarding to
+or has the wrong type. Call it on any `CourtEvent` before forwarding to
 external systems:
 
 ```ts
 import { assertEventPayload } from './events.js';
 
-store.subscribe(sessionId, (event) => {
+store.subscribe(sessionId, event => {
     assertEventPayload(event); // throws TypeError on malformed payload
     forwardToExternalSystem(event);
 });

--- a/public/index.html
+++ b/public/index.html
@@ -125,6 +125,19 @@
                 gap: 8px;
             }
 
+            .banner {
+                border: 1px solid #4f2f35;
+                background: color-mix(in srgb, var(--danger) 12%, #1a1216);
+                color: #ffd8de;
+                border-radius: 10px;
+                font-size: 13px;
+                padding: 8px 10px;
+            }
+
+            .hidden {
+                display: none;
+            }
+
             .overlay-row {
                 display: flex;
                 justify-content: space-between;
@@ -138,6 +151,31 @@
                 color: var(--text);
                 border-left: 3px solid #3b4160;
                 padding-left: 8px;
+            }
+
+            .timer-track {
+                width: 100%;
+                height: 7px;
+                border-radius: 999px;
+                background: #2b2f41;
+                overflow: hidden;
+            }
+
+            .timer-fill {
+                height: 100%;
+                width: 0%;
+                background: linear-gradient(90deg, #6f8dff, #88b4ff);
+                transition: width 180ms linear;
+            }
+
+            .speaker-live {
+                color: #d9e6ff;
+                text-shadow: 0 0 12px #88b4ff66;
+            }
+
+            .loading {
+                opacity: 0.65;
+                cursor: wait;
             }
 
             #feed {
@@ -241,6 +279,8 @@
                     style="border-color: #2b2f41; opacity: 0.6; margin: 16px 0"
                 />
 
+                <div id="connectionBanner" class="banner hidden"></div>
+
                 <div class="phase">
                     <div>
                         <h3 style="margin: 0">Live Transcript</h3>
@@ -254,6 +294,9 @@
                     <div class="overlay-row">
                         <span>⏱️ Phase timer</span>
                         <span id="phaseTimer">--:--</span>
+                    </div>
+                    <div class="timer-track">
+                        <div id="phaseTimerFill" class="timer-fill"></div>
                     </div>
                     <div class="overlay-row">
                         <span>🎙️ Active speaker</span>

--- a/src/court/orchestrator.test.ts
+++ b/src/court/orchestrator.test.ts
@@ -1,0 +1,477 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type { CourtPhase, CourtEvent } from '../types.js';
+import { AGENT_IDS, AGENTS } from '../agents.js';
+import { runCourtSession } from './orchestrator.js';
+import { assignCourtRoles } from './roles.js';
+import { createCourtSessionStore } from '../store/session-store.js';
+import { MockTTSAdapter } from '../tts/adapter.js';
+
+// Helper to create store with in-memory backend
+async function createTestStore() {
+    const previousDatabaseUrl = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = '';
+    try {
+        return await createCourtSessionStore();
+    } finally {
+        if (previousDatabaseUrl === undefined) {
+            delete process.env.DATABASE_URL;
+        } else {
+            process.env.DATABASE_URL = previousDatabaseUrl;
+        }
+    }
+}
+
+const PHASE_SEQUENCE: CourtPhase[] = [
+    'case_prompt',
+    'openings',
+    'witness_exam',
+    'evidence_reveal',
+    'closings',
+    'verdict_vote',
+    'sentence_vote',
+    'final_ruling',
+];
+
+describe('Court State Machine - Phase Transitions', () => {
+    it('should enforce forward-only phase transitions', async () => {
+        const store = await createTestStore();
+        const participants = Object.keys(AGENTS).slice(0, 6) as any[];
+
+        const session = await store.createSession({
+            topic: 'Test case for phase transitions',
+            participants,
+            metadata: {
+                mode: 'improv_court',
+                casePrompt: 'Test case for phase transitions',
+                caseType: 'criminal',
+                roleAssignments: {
+                    judge: participants[0],
+                    prosecutor: participants[1],
+                    defense: participants[2],
+                    witnesses: [participants[3], participants[4]],
+                    bailiff: participants[5],
+                },
+                sentenceOptions: [
+                    'fine',
+                    'probation',
+                    'jail',
+                    'community_service',
+                ],
+                verdictVoteWindowMs: 20000,
+                sentenceVoteWindowMs: 20000,
+                verdictVotes: {},
+                sentenceVotes: {},
+            },
+        });
+
+        await store.startSession(session.id);
+
+        // Test: can advance forward through sequence
+        await store.setPhase(session.id, 'openings');
+        await store.setPhase(session.id, 'witness_exam');
+        await store.setPhase(session.id, 'evidence_reveal');
+
+        // Test: backward transition should fail
+        await assert.rejects(
+            async () => store.setPhase(session.id, 'witness_exam'),
+            {
+                name: 'CourtValidationError',
+                message:
+                    'Invalid phase transition: evidence_reveal -> witness_exam',
+            },
+        );
+    });
+
+    it('should allow skipping evidence_reveal phase', async () => {
+        const store = await createTestStore();
+        const participants = Object.keys(AGENTS).slice(0, 6) as any[];
+
+        const session = await store.createSession({
+            topic: 'Test case for skipping evidence reveal',
+            participants,
+            metadata: {
+                mode: 'improv_court',
+                casePrompt: 'Test case for phase transitions',
+                caseType: 'criminal',
+                roleAssignments: {
+                    judge: participants[0],
+                    prosecutor: participants[1],
+                    defense: participants[2],
+                    witnesses: [participants[3], participants[4]],
+                    bailiff: participants[5],
+                },
+                sentenceOptions: [
+                    'fine',
+                    'probation',
+                    'jail',
+                    'community_service',
+                ],
+                verdictVoteWindowMs: 20000,
+                sentenceVoteWindowMs: 20000,
+                verdictVotes: {},
+                sentenceVotes: {},
+            },
+        });
+
+        await store.startSession(session.id);
+        await store.setPhase(session.id, 'openings');
+        await store.setPhase(session.id, 'witness_exam');
+
+        // Test: can skip evidence_reveal and go directly to closings
+        await store.setPhase(session.id, 'closings');
+
+        const updated = await store.getSession(session.id);
+        assert.equal(updated?.phase, 'closings');
+    });
+
+    it('should reject jumps that skip multiple phases', async () => {
+        const store = await createTestStore();
+        const participants = Object.keys(AGENTS).slice(0, 6) as any[];
+
+        const session = await store.createSession({
+            topic: 'Test case for invalid jumps',
+            participants,
+            metadata: {
+                mode: 'improv_court',
+                casePrompt: 'Test case for invalid jumps',
+                caseType: 'criminal',
+                roleAssignments: {
+                    judge: participants[0],
+                    prosecutor: participants[1],
+                    defense: participants[2],
+                    witnesses: [participants[3]],
+                    bailiff: participants[4],
+                },
+                sentenceOptions: ['fine'],
+                verdictVoteWindowMs: 20000,
+                sentenceVoteWindowMs: 20000,
+                verdictVotes: {},
+                sentenceVotes: {},
+            },
+        });
+
+        await store.startSession(session.id);
+
+        // Test: cannot jump from case_prompt to closings
+        await assert.rejects(
+            async () => store.setPhase(session.id, 'closings'),
+            {
+                name: 'CourtValidationError',
+                message: 'Invalid phase transition: case_prompt -> closings',
+            },
+        );
+
+        // Test: cannot jump from case_prompt to verdict_vote
+        await assert.rejects(
+            async () => store.setPhase(session.id, 'verdict_vote'),
+            {
+                name: 'CourtValidationError',
+                message:
+                    'Invalid phase transition: case_prompt -> verdict_vote',
+            },
+        );
+    });
+
+    it('should allow no-op phase transitions (same phase)', async () => {
+        const store = await createTestStore();
+        const participants = Object.keys(AGENTS).slice(0, 6) as any[];
+
+        const session = await store.createSession({
+            topic: 'Test case for no-op transitions',
+            participants,
+            metadata: {
+                mode: 'improv_court',
+                casePrompt: 'Test case for no-op transitions',
+                caseType: 'civil',
+                roleAssignments: {
+                    judge: participants[0],
+                    prosecutor: participants[1],
+                    defense: participants[2],
+                    witnesses: [participants[3]],
+                    bailiff: participants[4],
+                },
+                sentenceOptions: ['damages'],
+                verdictVoteWindowMs: 20000,
+                sentenceVoteWindowMs: 20000,
+                verdictVotes: {},
+                sentenceVotes: {},
+            },
+        });
+
+        await store.startSession(session.id);
+
+        // Test: setting phase to same phase should succeed (no-op)
+        await store.setPhase(session.id, 'case_prompt');
+        const updated = await store.getSession(session.id);
+        assert.equal(updated?.phase, 'case_prompt');
+    });
+
+    it('should emit phase_changed events on transitions', async () => {
+        const store = await createTestStore();
+        const participants = Object.keys(AGENTS).slice(0, 6) as any[];
+
+        const session = await store.createSession({
+            topic: 'Test case for phase events',
+            participants,
+            metadata: {
+                mode: 'improv_court',
+                casePrompt: 'Test case for phase events',
+                caseType: 'criminal',
+                roleAssignments: {
+                    judge: participants[0],
+                    prosecutor: participants[1],
+                    defense: participants[2],
+                    witnesses: [participants[3]],
+                    bailiff: participants[4],
+                },
+                sentenceOptions: ['fine'],
+                verdictVoteWindowMs: 20000,
+                sentenceVoteWindowMs: 20000,
+                verdictVotes: {},
+                sentenceVotes: {},
+            },
+        });
+
+        await store.startSession(session.id);
+
+        const events: CourtEvent[] = [];
+        store.subscribe(session.id, (event: CourtEvent) => {
+            if (event.type === 'phase_changed') {
+                events.push(event);
+            }
+        });
+
+        await store.setPhase(session.id, 'openings', 30000);
+
+        assert.equal(events.length, 1);
+        assert.equal(events[0].type, 'phase_changed');
+        assert.equal(events[0].payload.phase, 'openings');
+        assert.equal(events[0].payload.phaseDurationMs, 30000);
+    });
+
+    it('should verify phase graph has no dead ends except final_ruling', () => {
+        // Property test: every phase except final_ruling should have at least one valid next phase
+        for (let i = 0; i < PHASE_SEQUENCE.length - 1; i++) {
+            const phase = PHASE_SEQUENCE[i];
+            const hasNextPhase =
+                i < PHASE_SEQUENCE.length - 1 || // Can advance to next
+                (phase === 'witness_exam' && i + 2 < PHASE_SEQUENCE.length); // Or skip evidence_reveal
+
+            assert.ok(
+                hasNextPhase,
+                `Phase ${phase} should have at least one valid next phase`,
+            );
+        }
+
+        // final_ruling is the only terminal phase
+        const finalPhase = PHASE_SEQUENCE[PHASE_SEQUENCE.length - 1];
+        assert.equal(
+            finalPhase,
+            'final_ruling',
+            'final_ruling should be the last phase',
+        );
+    });
+
+    it('should verify all phases are reachable from case_prompt', () => {
+        // Property test: every phase should be reachable from case_prompt
+        const reachable = new Set<CourtPhase>(['case_prompt']);
+
+        for (let i = 0; i < PHASE_SEQUENCE.length - 1; i++) {
+            const current = PHASE_SEQUENCE[i];
+            if (reachable.has(current)) {
+                // Can reach next phase
+                const next = PHASE_SEQUENCE[i + 1];
+                if (next) reachable.add(next);
+
+                // Special case: can skip evidence_reveal
+                if (current === 'witness_exam') {
+                    const closingsIndex = PHASE_SEQUENCE.indexOf('closings');
+                    if (closingsIndex !== -1) {
+                        reachable.add(PHASE_SEQUENCE[closingsIndex]);
+                    }
+                }
+            }
+        }
+
+        for (const phase of PHASE_SEQUENCE) {
+            assert.ok(
+                reachable.has(phase),
+                `Phase ${phase} should be reachable from case_prompt`,
+            );
+        }
+    });
+
+    it('should verify transition invariant: no backward jumps allowed', async () => {
+        const store = await createTestStore();
+        const participants = Object.keys(AGENTS).slice(0, 6) as any[];
+
+        const session = await store.createSession({
+            topic: 'Test case for backward jump prevention',
+            participants,
+            metadata: {
+                mode: 'improv_court',
+                casePrompt: 'Test case for backward jump prevention',
+                caseType: 'criminal',
+                roleAssignments: {
+                    judge: participants[0],
+                    prosecutor: participants[1],
+                    defense: participants[2],
+                    witnesses: [participants[3]],
+                    bailiff: participants[4],
+                },
+                sentenceOptions: ['fine'],
+                verdictVoteWindowMs: 20000,
+                sentenceVoteWindowMs: 20000,
+                verdictVotes: {},
+                sentenceVotes: {},
+            },
+        });
+
+        await store.startSession(session.id);
+        await store.setPhase(session.id, 'openings');
+        await store.setPhase(session.id, 'witness_exam');
+        await store.setPhase(session.id, 'closings');
+
+        // Test all backward transitions from closings
+        for (const targetPhase of [
+            'case_prompt',
+            'openings',
+            'witness_exam',
+            'evidence_reveal',
+        ]) {
+            await assert.rejects(
+                async () =>
+                    store.setPhase(session.id, targetPhase as CourtPhase),
+                {
+                    name: 'CourtValidationError',
+                },
+                `Should reject backward transition: closings -> ${targetPhase}`,
+            );
+        }
+    });
+
+    it('should emit poll_started events for vote phases', async () => {
+        const store = await createTestStore();
+        const participants = Object.keys(AGENTS).slice(0, 6) as any[];
+
+        const session = await store.createSession({
+            topic: 'Test case for poll events',
+            participants,
+            metadata: {
+                mode: 'improv_court',
+                casePrompt: 'Test case for poll events',
+                caseType: 'criminal',
+                roleAssignments: {
+                    judge: participants[0],
+                    prosecutor: participants[1],
+                    defense: participants[2],
+                    witnesses: [participants[3]],
+                    bailiff: participants[4],
+                },
+                sentenceOptions: ['fine', 'probation'],
+                verdictVoteWindowMs: 20000,
+                sentenceVoteWindowMs: 20000,
+                verdictVotes: {},
+                sentenceVotes: {},
+            },
+        });
+
+        await store.startSession(session.id);
+
+        const events: CourtEvent[] = [];
+        store.subscribe(session.id, (event: CourtEvent) => {
+            if (
+                event.type === 'analytics_event' &&
+                event.payload.name === 'poll_started'
+            ) {
+                events.push(event);
+            }
+        });
+
+        // Advance through phases to verdict_vote
+        await store.setPhase(session.id, 'openings');
+        await store.setPhase(session.id, 'witness_exam');
+        await store.setPhase(session.id, 'closings');
+        await store.setPhase(session.id, 'verdict_vote');
+
+        assert.equal(events.length, 1);
+        assert.equal(events[0].payload.pollType, 'verdict');
+        assert.equal(events[0].payload.phase, 'verdict_vote');
+    });
+});
+
+describe('Court Orchestrator - TTS integration', () => {
+    it('routes cues through adapter methods at phase milestones', async () => {
+        const store = await createTestStore();
+        const participants = AGENT_IDS;
+
+        const session = await store.createSession({
+            topic: 'Did the defendant replace office coffee with soup?',
+            participants,
+            metadata: {
+                mode: 'improv_court',
+                casePrompt:
+                    'Did the defendant replace office coffee with soup?',
+                caseType: 'criminal',
+                roleAssignments: assignCourtRoles(participants),
+                sentenceOptions: ['fine', 'probation'],
+                verdictVoteWindowMs: 1,
+                sentenceVoteWindowMs: 1,
+                verdictVotes: {},
+                sentenceVotes: {},
+            },
+        });
+
+        const adapter = new MockTTSAdapter();
+        await runCourtSession(session.id, store, {
+            ttsAdapter: adapter,
+            sleepFn: async () => {},
+        });
+
+        const completed = await store.getSession(session.id);
+        assert.equal(completed?.status, 'completed');
+        assert.ok(completed?.metadata.finalRuling);
+
+        const methods = adapter.calls.map(call => call.method);
+        assert.ok(methods.includes('speakCue'));
+        assert.ok(methods.includes('speakRecap'));
+        assert.ok(methods.includes('speakVerdict'));
+    });
+
+    it('does not fail session progression when TTS provider throws', async () => {
+        const store = await createTestStore();
+        const participants = AGENT_IDS;
+
+        const session = await store.createSession({
+            topic: 'Did the defendant install a trampoline in the jury box?',
+            participants,
+            metadata: {
+                mode: 'improv_court',
+                casePrompt:
+                    'Did the defendant install a trampoline in the jury box?',
+                caseType: 'criminal',
+                roleAssignments: assignCourtRoles(participants),
+                sentenceOptions: ['fine', 'probation'],
+                verdictVoteWindowMs: 1,
+                sentenceVoteWindowMs: 1,
+                verdictVotes: {},
+                sentenceVotes: {},
+            },
+        });
+
+        const failingAdapter = new MockTTSAdapter({
+            failOn: ['speakCue', 'speakRecap', 'speakVerdict'],
+        });
+
+        await runCourtSession(session.id, store, {
+            ttsAdapter: failingAdapter,
+            sleepFn: async () => {},
+        });
+
+        const completed = await store.getSession(session.id);
+        assert.equal(completed?.status, 'completed');
+        assert.ok(completed?.metadata.finalRuling);
+        assert.ok(failingAdapter.calls.length > 0);
+    });
+});

--- a/src/court/vote-tally.test.ts
+++ b/src/court/vote-tally.test.ts
@@ -1,0 +1,421 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type { CourtEvent } from '../types.js';
+import { createCourtSessionStore } from '../store/session-store.js';
+import { AGENTS } from '../agents.js';
+
+// Helper to create store with in-memory backend
+async function createTestStore() {
+    const previousDatabaseUrl = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = '';
+    try {
+        return await createCourtSessionStore();
+    } finally {
+        if (previousDatabaseUrl === undefined) {
+            delete process.env.DATABASE_URL;
+        } else {
+            process.env.DATABASE_URL = previousDatabaseUrl;
+        }
+    }
+}
+
+// Helper to pick winner from vote tallies (same logic as orchestrator's bestOf)
+function bestOf(votes: Record<string, number>, fallback: string): string {
+    const entries = Object.entries(votes);
+    if (entries.length === 0) return fallback;
+
+    const sorted = [...entries].sort((a, b) => b[1] - a[1]);
+    return sorted[0]?.[0] ?? fallback;
+}
+
+describe('Vote Tally Logic', () => {
+    it('should return choice with highest vote count', () => {
+        const votes = {
+            guilty: 15,
+            not_guilty: 8,
+        };
+
+        const winner = bestOf(votes, 'not_guilty');
+        assert.equal(winner, 'guilty');
+    });
+
+    it('should handle tie by selecting first sorted entry (deterministic)', () => {
+        const votes = {
+            guilty: 10,
+            not_guilty: 10,
+        };
+
+        // With a tie, sort() will pick lexicographically first after sorting by count
+        // Since both have count 10, the original order matters
+        // Array.sort is stable, so 'guilty' comes first
+        const winner = bestOf(votes, 'not_guilty');
+        assert.ok(winner === 'guilty' || winner === 'not_guilty');
+        // Determinism test: calling again should give same result
+        const winner2 = bestOf(votes, 'not_guilty');
+        assert.equal(winner, winner2);
+    });
+
+    it('should return fallback for empty vote counts', () => {
+        const votes = {};
+        const winner = bestOf(votes, 'not_guilty');
+        assert.equal(winner, 'not_guilty');
+    });
+
+    it('should handle three-way tie deterministically', () => {
+        const votes = {
+            fine: 5,
+            probation: 5,
+            jail: 5,
+        };
+
+        const winner = bestOf(votes, 'fine');
+        // Should be deterministic
+        const winner2 = bestOf(votes, 'fine');
+        assert.equal(winner, winner2);
+    });
+
+    it('should handle single choice', () => {
+        const votes = {
+            guilty: 1,
+        };
+
+        const winner = bestOf(votes, 'not_guilty');
+        assert.equal(winner, 'guilty');
+    });
+
+    it('should prefer choice with even one more vote', () => {
+        const votes = {
+            liable: 11,
+            not_liable: 10,
+        };
+
+        const winner = bestOf(votes, 'not_liable');
+        assert.equal(winner, 'liable');
+    });
+});
+
+describe('Vote Lifecycle Integration', () => {
+    it('should accept votes during verdict_vote phase only', async () => {
+        const store = await createTestStore();
+        const participants = Object.keys(AGENTS).slice(0, 6) as any[];
+
+        const session = await store.createSession({
+            topic: 'Test case for vote phase gating',
+            participants,
+            metadata: {
+                mode: 'improv_court',
+                casePrompt: 'Test case',
+                caseType: 'criminal',
+                roleAssignments: {
+                    judge: participants[0],
+                    prosecutor: participants[1],
+                    defense: participants[2],
+                    witnesses: [participants[3]],
+                    bailiff: participants[4],
+                },
+                sentenceOptions: ['fine', 'probation'],
+                verdictVoteWindowMs: 20000,
+                sentenceVoteWindowMs: 20000,
+                verdictVotes: {},
+                sentenceVotes: {},
+            },
+        });
+
+        await store.startSession(session.id);
+
+        // Cannot vote during case_prompt
+        await assert.rejects(
+            async () =>
+                store.castVote({
+                    sessionId: session.id,
+                    voteType: 'verdict',
+                    choice: 'guilty',
+                }),
+            {
+                name: 'CourtValidationError',
+                message: 'Cannot cast verdict vote during phase case_prompt',
+            },
+        );
+
+        // Advance to verdict_vote phase
+        await store.setPhase(session.id, 'openings');
+        await store.setPhase(session.id, 'witness_exam');
+        await store.setPhase(session.id, 'closings');
+        await store.setPhase(session.id, 'verdict_vote');
+
+        // Now votes should be accepted
+        await store.castVote({
+            sessionId: session.id,
+            voteType: 'verdict',
+            choice: 'guilty',
+        });
+
+        const updated = await store.getSession(session.id);
+        assert.equal(updated?.metadata.verdictVotes['guilty'], 1);
+    });
+
+    it('should accumulate votes for the same choice', async () => {
+        const store = await createTestStore();
+        const participants = Object.keys(AGENTS).slice(0, 6) as any[];
+
+        const session = await store.createSession({
+            topic: 'Test case for vote accumulation',
+            participants,
+            metadata: {
+                mode: 'improv_court',
+                casePrompt: 'Test case',
+                caseType: 'criminal',
+                roleAssignments: {
+                    judge: participants[0],
+                    prosecutor: participants[1],
+                    defense: participants[2],
+                    witnesses: [participants[3]],
+                    bailiff: participants[4],
+                },
+                sentenceOptions: ['fine', 'probation'],
+                verdictVoteWindowMs: 20000,
+                sentenceVoteWindowMs: 20000,
+                verdictVotes: {},
+                sentenceVotes: {},
+            },
+        });
+
+        await store.startSession(session.id);
+        await store.setPhase(session.id, 'openings');
+        await store.setPhase(session.id, 'witness_exam');
+        await store.setPhase(session.id, 'closings');
+        await store.setPhase(session.id, 'verdict_vote');
+
+        // Cast multiple votes for 'guilty'
+        await store.castVote({
+            sessionId: session.id,
+            voteType: 'verdict',
+            choice: 'guilty',
+        });
+        await store.castVote({
+            sessionId: session.id,
+            voteType: 'verdict',
+            choice: 'guilty',
+        });
+        await store.castVote({
+            sessionId: session.id,
+            voteType: 'verdict',
+            choice: 'guilty',
+        });
+
+        // Cast votes for 'not_guilty'
+        await store.castVote({
+            sessionId: session.id,
+            voteType: 'verdict',
+            choice: 'not_guilty',
+        });
+
+        const updated = await store.getSession(session.id);
+        assert.equal(updated?.metadata.verdictVotes['guilty'], 3);
+        assert.equal(updated?.metadata.verdictVotes['not_guilty'], 1);
+    });
+
+    it('should emit vote_updated event on each vote cast', async () => {
+        const store = await createTestStore();
+        const participants = Object.keys(AGENTS).slice(0, 6) as any[];
+
+        const session = await store.createSession({
+            topic: 'Test case for vote events',
+            participants,
+            metadata: {
+                mode: 'improv_court',
+                casePrompt: 'Test case',
+                caseType: 'criminal',
+                roleAssignments: {
+                    judge: participants[0],
+                    prosecutor: participants[1],
+                    defense: participants[2],
+                    witnesses: [participants[3]],
+                    bailiff: participants[4],
+                },
+                sentenceOptions: ['fine'],
+                verdictVoteWindowMs: 20000,
+                sentenceVoteWindowMs: 20000,
+                verdictVotes: {},
+                sentenceVotes: {},
+            },
+        });
+
+        await store.startSession(session.id);
+        await store.setPhase(session.id, 'openings');
+        await store.setPhase(session.id, 'witness_exam');
+        await store.setPhase(session.id, 'closings');
+        await store.setPhase(session.id, 'verdict_vote');
+
+        const events: CourtEvent[] = [];
+        store.subscribe(session.id, (event: CourtEvent) => {
+            if (event.type === 'vote_updated') {
+                events.push(event);
+            }
+        });
+
+        await store.castVote({
+            sessionId: session.id,
+            voteType: 'verdict',
+            choice: 'guilty',
+        });
+
+        assert.equal(events.length, 1);
+        assert.equal(events[0].type, 'vote_updated');
+        assert.equal(events[0].payload.voteType, 'verdict');
+        assert.equal(events[0].payload.choice, 'guilty');
+        assert.ok(events[0].payload.verdictVotes);
+    });
+
+    it('should reject invalid verdict choices', async () => {
+        const store = await createTestStore();
+        const participants = Object.keys(AGENTS).slice(0, 6) as any[];
+
+        const session = await store.createSession({
+            topic: 'Test case for invalid choices',
+            participants,
+            metadata: {
+                mode: 'improv_court',
+                casePrompt: 'Test case',
+                caseType: 'criminal',
+                roleAssignments: {
+                    judge: participants[0],
+                    prosecutor: participants[1],
+                    defense: participants[2],
+                    witnesses: [participants[3]],
+                    bailiff: participants[4],
+                },
+                sentenceOptions: ['fine'],
+                verdictVoteWindowMs: 20000,
+                sentenceVoteWindowMs: 20000,
+                verdictVotes: {},
+                sentenceVotes: {},
+            },
+        });
+
+        await store.startSession(session.id);
+        await store.setPhase(session.id, 'openings');
+        await store.setPhase(session.id, 'witness_exam');
+        await store.setPhase(session.id, 'closings');
+        await store.setPhase(session.id, 'verdict_vote');
+
+        await assert.rejects(
+            async () =>
+                store.castVote({
+                    sessionId: session.id,
+                    voteType: 'verdict',
+                    choice: 'super_guilty',
+                }),
+            {
+                name: 'CourtValidationError',
+                message: /Invalid verdict choice/,
+            },
+        );
+    });
+
+    it('should reject invalid sentence choices', async () => {
+        const store = await createTestStore();
+        const participants = Object.keys(AGENTS).slice(0, 6) as any[];
+
+        const session = await store.createSession({
+            topic: 'Test case for invalid sentence',
+            participants,
+            metadata: {
+                mode: 'improv_court',
+                casePrompt: 'Test case',
+                caseType: 'criminal',
+                roleAssignments: {
+                    judge: participants[0],
+                    prosecutor: participants[1],
+                    defense: participants[2],
+                    witnesses: [participants[3]],
+                    bailiff: participants[4],
+                },
+                sentenceOptions: ['fine', 'probation'],
+                verdictVoteWindowMs: 20000,
+                sentenceVoteWindowMs: 20000,
+                verdictVotes: {},
+                sentenceVotes: {},
+            },
+        });
+
+        await store.startSession(session.id);
+        await store.setPhase(session.id, 'openings');
+        await store.setPhase(session.id, 'witness_exam');
+        await store.setPhase(session.id, 'closings');
+        await store.setPhase(session.id, 'verdict_vote');
+        await store.setPhase(session.id, 'sentence_vote');
+
+        await assert.rejects(
+            async () =>
+                store.castVote({
+                    sessionId: session.id,
+                    voteType: 'sentence',
+                    choice: 'death_penalty',
+                }),
+            {
+                name: 'CourtValidationError',
+                message: /Invalid sentence choice/,
+            },
+        );
+    });
+
+    it('should handle sentence votes independently from verdict votes', async () => {
+        const store = await createTestStore();
+        const participants = Object.keys(AGENTS).slice(0, 6) as any[];
+
+        const session = await store.createSession({
+            topic: 'Test case for sentence voting',
+            participants,
+            metadata: {
+                mode: 'improv_court',
+                casePrompt: 'Test case',
+                caseType: 'criminal',
+                roleAssignments: {
+                    judge: participants[0],
+                    prosecutor: participants[1],
+                    defense: participants[2],
+                    witnesses: [participants[3]],
+                    bailiff: participants[4],
+                },
+                sentenceOptions: ['fine', 'probation', 'jail'],
+                verdictVoteWindowMs: 20000,
+                sentenceVoteWindowMs: 20000,
+                verdictVotes: {},
+                sentenceVotes: {},
+            },
+        });
+
+        await store.startSession(session.id);
+        await store.setPhase(session.id, 'openings');
+        await store.setPhase(session.id, 'witness_exam');
+        await store.setPhase(session.id, 'closings');
+        await store.setPhase(session.id, 'verdict_vote');
+        await store.setPhase(session.id, 'sentence_vote');
+
+        await store.castVote({
+            sessionId: session.id,
+            voteType: 'sentence',
+            choice: 'probation',
+        });
+        await store.castVote({
+            sessionId: session.id,
+            voteType: 'sentence',
+            choice: 'fine',
+        });
+        await store.castVote({
+            sessionId: session.id,
+            voteType: 'sentence',
+            choice: 'probation',
+        });
+
+        const updated = await store.getSession(session.id);
+        assert.equal(updated?.metadata.sentenceVotes['probation'], 2);
+        assert.equal(updated?.metadata.sentenceVotes['fine'], 1);
+        // Verdict votes should still be empty
+        assert.equal(
+            Object.keys(updated?.metadata.verdictVotes ?? {}).length,
+            0,
+        );
+    });
+});

--- a/src/events.test.ts
+++ b/src/events.test.ts
@@ -22,9 +22,7 @@ function makeEvent(
 
 test('assertEventPayload: session_created valid', () => {
     assert.doesNotThrow(() =>
-        assertEventPayload(
-            makeEvent('session_created', { sessionId: 'abc' }),
-        ),
+        assertEventPayload(makeEvent('session_created', { sessionId: 'abc' })),
     );
 });
 
@@ -78,6 +76,19 @@ test('assertEventPayload: vote_updated valid', () => {
                 choice: 'guilty',
                 verdictVotes: { guilty: 1 },
                 sentenceVotes: {},
+            }),
+        ),
+    );
+});
+
+test('assertEventPayload: vote_closed valid', () => {
+    assert.doesNotThrow(() =>
+        assertEventPayload(
+            makeEvent('vote_closed', {
+                pollType: 'verdict',
+                closedAt: new Date().toISOString(),
+                votes: { guilty: 3, not_guilty: 2 },
+                nextPhase: 'sentence_vote',
             }),
         ),
     );
@@ -221,6 +232,20 @@ test('assertEventPayload: vote_updated missing verdictVotes', () => {
                     voteType: 'verdict',
                     choice: 'guilty',
                     sentenceVotes: {},
+                }),
+            ),
+        TypeError,
+    );
+});
+
+test('assertEventPayload: vote_closed missing votes', () => {
+    assert.throws(
+        () =>
+            assertEventPayload(
+                makeEvent('vote_closed', {
+                    pollType: 'verdict',
+                    closedAt: new Date().toISOString(),
+                    nextPhase: 'sentence_vote',
                 }),
             ),
         TypeError,

--- a/src/events.ts
+++ b/src/events.ts
@@ -46,7 +46,17 @@ export interface VoteUpdatedPayload {
     sentenceVotes: Record<string, number>;
 }
 
-export type AnalyticsEventName = 'poll_started' | 'vote_completed' | 'poll_closed';
+export interface VoteClosedPayload {
+    pollType: 'verdict' | 'sentence';
+    closedAt: string; // ISO 8601
+    votes: Record<string, number>;
+    nextPhase: CourtPhase;
+}
+
+export type AnalyticsEventName =
+    | 'poll_started'
+    | 'vote_completed'
+    | 'poll_closed';
 
 export interface AnalyticsEventPayload {
     name: AnalyticsEventName;
@@ -89,10 +99,7 @@ function hasStringKeys(
     return keys.every(k => typeof payload[k] === 'string');
 }
 
-function hasObjectKey(
-    payload: Record<string, unknown>,
-    key: string,
-): boolean {
+function hasObjectKey(payload: Record<string, unknown>, key: string): boolean {
     return (
         payload[key] !== null &&
         typeof payload[key] === 'object' &&
@@ -148,6 +155,21 @@ export function assertEventPayload(event: CourtEvent): void {
             ) {
                 throw new TypeError(
                     `vote_updated payload missing required fields: voteType, choice, verdictVotes, sentenceVotes`,
+                );
+            }
+            break;
+
+        case 'vote_closed':
+            if (
+                !hasStringKeys(payload, [
+                    'pollType',
+                    'closedAt',
+                    'nextPhase',
+                ]) ||
+                !hasObjectKey(payload, 'votes')
+            ) {
+                throw new TypeError(
+                    `vote_closed payload missing required fields: pollType, closedAt, votes, nextPhase`,
                 );
             }
             break;

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,0 +1,165 @@
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import test, { after, before } from 'node:test';
+import { createServerApp } from './server.js';
+
+let server: Server;
+let baseUrl = '';
+let dispose: () => void;
+let previousDatabaseUrl: string | undefined;
+
+before(async () => {
+    previousDatabaseUrl = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = '';
+
+    const created = await createServerApp({
+        autoRunCourtSession: false,
+    });
+
+    dispose = created.dispose;
+    server = created.app.listen(0);
+    await once(server, 'listening');
+
+    const address = server.address() as AddressInfo | null;
+    if (!address || typeof address === 'string') {
+        throw new Error('Expected server to bind to an ephemeral TCP port');
+    }
+
+    baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+after(async () => {
+    await new Promise<void>(resolve => {
+        server.close(() => resolve());
+    });
+    dispose();
+
+    if (previousDatabaseUrl === undefined) {
+        delete process.env.DATABASE_URL;
+    } else {
+        process.env.DATABASE_URL = previousDatabaseUrl;
+    }
+});
+
+async function postJson(path: string, body: Record<string, unknown>) {
+    const response = await fetch(`${baseUrl}${path}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+    });
+
+    const json = (await response.json()) as Record<string, unknown>;
+    return { response, json };
+}
+
+async function createSessionId(): Promise<string> {
+    const { response, json } = await postJson('/api/court/sessions', {
+        topic: 'Did the defendant replace all office coffee with soup?',
+        caseType: 'criminal',
+    });
+
+    assert.equal(response.status, 201);
+    const session = json.session as { id: string };
+    assert.ok(session?.id);
+    return session.id;
+}
+
+test('POST /api/court/sessions rejects short topic with explicit code', async () => {
+    const { response, json } = await postJson('/api/court/sessions', {
+        topic: 'too short',
+    });
+
+    assert.equal(response.status, 400);
+    assert.equal(json.code, 'INVALID_TOPIC');
+    assert.equal(json.error, 'topic must be at least 10 characters');
+});
+
+test('POST /api/court/sessions/:id/vote rejects invalid vote type', async () => {
+    const sessionId = await createSessionId();
+
+    const { response, json } = await postJson(
+        `/api/court/sessions/${sessionId}/vote`,
+        {
+            type: 'banana',
+            choice: 'guilty',
+        },
+    );
+
+    assert.equal(response.status, 400);
+    assert.equal(json.code, 'INVALID_VOTE_TYPE');
+});
+
+test('POST /api/court/sessions/:id/vote rejects empty choice', async () => {
+    const sessionId = await createSessionId();
+
+    const { response, json } = await postJson(
+        `/api/court/sessions/${sessionId}/vote`,
+        {
+            type: 'verdict',
+            choice: '   ',
+        },
+    );
+
+    assert.equal(response.status, 400);
+    assert.equal(json.code, 'MISSING_VOTE_CHOICE');
+});
+
+test('POST /api/court/sessions/:id/vote rejects vote outside active vote phase', async () => {
+    const sessionId = await createSessionId();
+
+    const { response, json } = await postJson(
+        `/api/court/sessions/${sessionId}/vote`,
+        {
+            type: 'verdict',
+            choice: 'guilty',
+        },
+    );
+
+    assert.equal(response.status, 400);
+    assert.equal(json.code, 'VOTE_REJECTED');
+    assert.match(
+        String(json.error),
+        /Cannot cast verdict vote during phase case_prompt/,
+    );
+});
+
+test('POST /api/court/sessions/:id/phase rejects invalid phase values', async () => {
+    const sessionId = await createSessionId();
+
+    const { response, json } = await postJson(
+        `/api/court/sessions/${sessionId}/phase`,
+        {
+            phase: 'bananas',
+        },
+    );
+
+    assert.equal(response.status, 400);
+    assert.equal(json.code, 'INVALID_PHASE');
+    assert.equal(json.error, 'invalid phase');
+});
+
+test('POST /api/court/sessions/:id/phase rejects illegal phase transitions', async () => {
+    const sessionId = await createSessionId();
+
+    const { response, json } = await postJson(
+        `/api/court/sessions/${sessionId}/phase`,
+        {
+            phase: 'closings',
+        },
+    );
+
+    assert.equal(response.status, 400);
+    assert.equal(json.code, 'INVALID_PHASE_TRANSITION');
+    assert.match(String(json.error), /Invalid phase transition/);
+});
+
+test('GET /api/court/sessions/:id returns SESSION_NOT_FOUND for unknown id', async () => {
+    const response = await fetch(`${baseUrl}/api/court/sessions/not-real`);
+    const json = (await response.json()) as Record<string, unknown>;
+
+    assert.equal(response.status, 404);
+    assert.equal(json.code, 'SESSION_NOT_FOUND');
+    assert.equal(json.error, 'Session not found');
+});

--- a/src/store/session-store.test.ts
+++ b/src/store/session-store.test.ts
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { AGENT_IDS } from '../agents.js';
 import { assignCourtRoles } from '../court/roles.js';
+import type { CourtEvent } from '../types.js';
 import { createCourtSessionStore } from './session-store.js';
 
 async function createRunningSession() {
@@ -15,7 +16,8 @@ async function createRunningSession() {
             participants,
             metadata: {
                 mode: 'improv_court',
-                casePrompt: 'Did the defendant replace all office coffee with soup?',
+                casePrompt:
+                    'Did the defendant replace all office coffee with soup?',
                 caseType: 'criminal',
                 sentenceOptions: ['Fine', 'Community service'],
                 verdictVoteWindowMs: 10,
@@ -156,6 +158,69 @@ test('emits analytics events for poll lifecycle and vote completion', async () =
     ]);
 });
 
+test('emits vote_closed and persists vote snapshots when vote phases end', async () => {
+    const { store, sessionId } = await createRunningSession();
+    const voteClosedEvents: CourtEvent[] = [];
+
+    const unsubscribe = store.subscribe(sessionId, event => {
+        if (event.type === 'vote_closed') {
+            voteClosedEvents.push(event);
+        }
+    });
+
+    try {
+        await store.setPhase(sessionId, 'openings');
+        await store.setPhase(sessionId, 'witness_exam');
+        await store.setPhase(sessionId, 'closings');
+        await store.setPhase(sessionId, 'verdict_vote');
+
+        await store.castVote({
+            sessionId,
+            voteType: 'verdict',
+            choice: 'guilty',
+        });
+        await store.castVote({
+            sessionId,
+            voteType: 'verdict',
+            choice: 'guilty',
+        });
+
+        await store.setPhase(sessionId, 'sentence_vote');
+
+        await store.castVote({
+            sessionId,
+            voteType: 'sentence',
+            choice: 'Fine',
+        });
+
+        await store.setPhase(sessionId, 'final_ruling');
+    } finally {
+        unsubscribe();
+    }
+
+    assert.equal(voteClosedEvents.length, 2);
+
+    assert.equal(voteClosedEvents[0]?.payload.pollType, 'verdict');
+    assert.equal(voteClosedEvents[0]?.payload.nextPhase, 'sentence_vote');
+    assert.deepEqual(voteClosedEvents[0]?.payload.votes, { guilty: 2 });
+    assert.equal(typeof voteClosedEvents[0]?.payload.closedAt, 'string');
+
+    assert.equal(voteClosedEvents[1]?.payload.pollType, 'sentence');
+    assert.equal(voteClosedEvents[1]?.payload.nextPhase, 'final_ruling');
+    assert.deepEqual(voteClosedEvents[1]?.payload.votes, { Fine: 1 });
+    assert.equal(typeof voteClosedEvents[1]?.payload.closedAt, 'string');
+
+    const session = await store.getSession(sessionId);
+    assert.ok(session?.metadata.voteSnapshots?.verdict?.closedAt);
+    assert.deepEqual(session?.metadata.voteSnapshots?.verdict?.votes, {
+        guilty: 2,
+    });
+    assert.ok(session?.metadata.voteSnapshots?.sentence?.closedAt);
+    assert.deepEqual(session?.metadata.voteSnapshots?.sentence?.votes, {
+        Fine: 1,
+    });
+});
+
 test(
     'postgres store persists final ruling when TEST_DATABASE_URL is provided',
     { skip: !process.env.TEST_DATABASE_URL },
@@ -191,6 +256,91 @@ test(
             assert.equal(reloaded?.metadata.finalRuling?.verdict, 'guilty');
             assert.equal(reloaded?.metadata.finalRuling?.sentence, 'Fine');
             assert.ok(reloaded?.metadata.finalRuling?.decidedAt);
+        } finally {
+            if (previousDatabaseUrl === undefined) {
+                delete process.env.DATABASE_URL;
+            } else {
+                process.env.DATABASE_URL = previousDatabaseUrl;
+            }
+        }
+    },
+);
+
+test('in-memory store returns empty list for restart recovery', async () => {
+    const { store } = await createRunningSession();
+    const recovered = await store.recoverInterruptedSessions();
+    assert.equal(recovered.length, 0);
+});
+
+test(
+    'postgres store returns running session IDs for restart recovery',
+    { skip: !process.env.TEST_DATABASE_URL },
+    async () => {
+        const previousDatabaseUrl = process.env.DATABASE_URL;
+        process.env.DATABASE_URL = process.env.TEST_DATABASE_URL;
+        try {
+            const store = await createCourtSessionStore();
+            const participants = AGENT_IDS.slice(0, 5);
+
+            // Create and start two sessions
+            const session1 = await store.createSession({
+                topic: 'Test case 1 for recovery',
+                participants,
+                metadata: {
+                    mode: 'improv_court',
+                    casePrompt: 'Test case 1',
+                    caseType: 'criminal',
+                    sentenceOptions: ['Fine'],
+                    verdictVoteWindowMs: 10,
+                    sentenceVoteWindowMs: 10,
+                    verdictVotes: {},
+                    sentenceVotes: {},
+                    roleAssignments: assignCourtRoles(participants),
+                },
+            });
+            await store.startSession(session1.id);
+
+            const session2 = await store.createSession({
+                topic: 'Test case 2 for recovery',
+                participants,
+                metadata: {
+                    mode: 'improv_court',
+                    casePrompt: 'Test case 2',
+                    caseType: 'criminal',
+                    sentenceOptions: ['Fine'],
+                    verdictVoteWindowMs: 10,
+                    sentenceVoteWindowMs: 10,
+                    verdictVotes: {},
+                    sentenceVotes: {},
+                    roleAssignments: assignCourtRoles(participants),
+                },
+            });
+            await store.startSession(session2.id);
+
+            // Create but don't start a third session
+            const session3 = await store.createSession({
+                topic: 'Test case 3 for recovery',
+                participants,
+                metadata: {
+                    mode: 'improv_court',
+                    casePrompt: 'Test case 3',
+                    caseType: 'criminal',
+                    sentenceOptions: ['Fine'],
+                    verdictVoteWindowMs: 10,
+                    sentenceVoteWindowMs: 10,
+                    verdictVotes: {},
+                    sentenceVotes: {},
+                    roleAssignments: assignCourtRoles(participants),
+                },
+            });
+
+            // Complete the first session
+            await store.completeSession(session1.id);
+
+            // Recovery should return only session2 (running, not completed)
+            const recovered = await store.recoverInterruptedSessions();
+            assert.equal(recovered.length, 1);
+            assert.equal(recovered[0], session2.id);
         } finally {
             if (previousDatabaseUrl === undefined) {
                 delete process.env.DATABASE_URL;

--- a/src/tts/adapter.test.ts
+++ b/src/tts/adapter.test.ts
@@ -1,0 +1,105 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    createTTSAdapterFromEnv,
+    MockTTSAdapter,
+    NoopTTSAdapter,
+} from './adapter.js';
+
+test('createTTSAdapterFromEnv defaults to noop provider', async () => {
+    const previousProvider = process.env.TTS_PROVIDER;
+    delete process.env.TTS_PROVIDER;
+
+    try {
+        const adapter = createTTSAdapterFromEnv();
+        assert.equal(adapter.provider, 'noop');
+        assert.ok(adapter instanceof NoopTTSAdapter);
+        await assert.doesNotReject(
+            adapter.speakCue({
+                sessionId: 'sess-1',
+                phase: 'case_prompt',
+                text: 'All rise.',
+            }),
+        );
+    } finally {
+        if (previousProvider === undefined) {
+            delete process.env.TTS_PROVIDER;
+        } else {
+            process.env.TTS_PROVIDER = previousProvider;
+        }
+    }
+});
+
+test('createTTSAdapterFromEnv falls back to noop for unknown providers', () => {
+    const previousProvider = process.env.TTS_PROVIDER;
+    process.env.TTS_PROVIDER = 'definitely-not-real';
+
+    try {
+        const adapter = createTTSAdapterFromEnv();
+        assert.equal(adapter.provider, 'noop');
+    } finally {
+        if (previousProvider === undefined) {
+            delete process.env.TTS_PROVIDER;
+        } else {
+            process.env.TTS_PROVIDER = previousProvider;
+        }
+    }
+});
+
+test('mock adapter records cue/recap/verdict calls', async () => {
+    const adapter = new MockTTSAdapter();
+
+    await adapter.speakCue({
+        sessionId: 'sess-1',
+        phase: 'openings',
+        text: 'Openings begin.',
+    });
+    await adapter.speakRecap({
+        sessionId: 'sess-1',
+        phase: 'witness_exam',
+        text: 'Recap text',
+    });
+    await adapter.speakVerdict({
+        sessionId: 'sess-1',
+        verdict: 'guilty',
+        sentence: 'fine',
+    });
+
+    assert.equal(adapter.calls.length, 3);
+    assert.equal(adapter.calls[0]?.method, 'speakCue');
+    assert.equal(adapter.calls[1]?.method, 'speakRecap');
+    assert.equal(adapter.calls[2]?.method, 'speakVerdict');
+});
+
+test('mock adapter can simulate provider failures', async () => {
+    const adapter = new MockTTSAdapter({
+        failOn: ['speakCue', 'speakRecap', 'speakVerdict'],
+    });
+
+    await assert.rejects(
+        adapter.speakCue({
+            sessionId: 'sess-1',
+            phase: 'case_prompt',
+            text: 'All rise.',
+        }),
+        /mock speakCue failure/,
+    );
+
+    await assert.rejects(
+        adapter.speakRecap({
+            sessionId: 'sess-1',
+            phase: 'witness_exam',
+            text: 'Recap.',
+        }),
+        /mock speakRecap failure/,
+    );
+
+    await assert.rejects(
+        adapter.speakVerdict({
+            sessionId: 'sess-1',
+            verdict: 'guilty',
+            sentence: 'fine',
+        }),
+        /mock speakVerdict failure/,
+    );
+});

--- a/src/tts/adapter.ts
+++ b/src/tts/adapter.ts
@@ -1,0 +1,99 @@
+import type { CourtPhase } from '../types.js';
+
+export interface SpeakCueInput {
+    sessionId: string;
+    phase: CourtPhase;
+    text: string;
+}
+
+export interface SpeakVerdictInput {
+    sessionId: string;
+    verdict: string;
+    sentence: string;
+}
+
+export interface SpeakRecapInput {
+    sessionId: string;
+    phase: CourtPhase;
+    text: string;
+}
+
+export interface TTSAdapter {
+    readonly provider: string;
+    speakCue(input: SpeakCueInput): Promise<void>;
+    speakVerdict(input: SpeakVerdictInput): Promise<void>;
+    speakRecap(input: SpeakRecapInput): Promise<void>;
+}
+
+export class NoopTTSAdapter implements TTSAdapter {
+    readonly provider = 'noop';
+
+    async speakCue(_input: SpeakCueInput): Promise<void> {
+        return;
+    }
+
+    async speakVerdict(_input: SpeakVerdictInput): Promise<void> {
+        return;
+    }
+
+    async speakRecap(_input: SpeakRecapInput): Promise<void> {
+        return;
+    }
+}
+
+export interface MockTTSAdapterOptions {
+    failOn?: Array<'speakCue' | 'speakVerdict' | 'speakRecap'>;
+}
+
+export class MockTTSAdapter implements TTSAdapter {
+    readonly provider = 'mock';
+    readonly calls: Array<
+        | { method: 'speakCue'; input: SpeakCueInput }
+        | { method: 'speakVerdict'; input: SpeakVerdictInput }
+        | { method: 'speakRecap'; input: SpeakRecapInput }
+    > = [];
+
+    private readonly failOn: Set<'speakCue' | 'speakVerdict' | 'speakRecap'>;
+
+    constructor(options: MockTTSAdapterOptions = {}) {
+        this.failOn = new Set(options.failOn ?? []);
+    }
+
+    async speakCue(input: SpeakCueInput): Promise<void> {
+        this.calls.push({ method: 'speakCue', input });
+        if (this.failOn.has('speakCue')) {
+            throw new Error('mock speakCue failure');
+        }
+    }
+
+    async speakVerdict(input: SpeakVerdictInput): Promise<void> {
+        this.calls.push({ method: 'speakVerdict', input });
+        if (this.failOn.has('speakVerdict')) {
+            throw new Error('mock speakVerdict failure');
+        }
+    }
+
+    async speakRecap(input: SpeakRecapInput): Promise<void> {
+        this.calls.push({ method: 'speakRecap', input });
+        if (this.failOn.has('speakRecap')) {
+            throw new Error('mock speakRecap failure');
+        }
+    }
+}
+
+export function createTTSAdapterFromEnv(): TTSAdapter {
+    const provider = (process.env.TTS_PROVIDER ?? 'noop').trim().toLowerCase();
+
+    switch (provider) {
+        case 'noop':
+            return new NoopTTSAdapter();
+        case 'mock':
+            return new MockTTSAdapter();
+        default:
+            // eslint-disable-next-line no-console
+            console.warn(
+                `[tts] Unknown TTS_PROVIDER=${provider}; falling back to noop adapter`,
+            );
+            return new NoopTTSAdapter();
+    }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,16 @@ export interface CourtSessionMetadata {
     sentenceVoteWindowMs: number;
     verdictVotes: Record<string, number>;
     sentenceVotes: Record<string, number>;
+    voteSnapshots?: {
+        verdict?: {
+            closedAt: string;
+            votes: Record<string, number>;
+        };
+        sentence?: {
+            closedAt: string;
+            votes: Record<string, number>;
+        };
+    };
     finalRuling?: {
         verdict: string;
         sentence: string;
@@ -110,6 +120,7 @@ export type CourtEventType =
     | 'phase_changed'
     | 'turn'
     | 'vote_updated'
+    | 'vote_closed'
     | 'analytics_event'
     | 'moderation_action'
     | 'vote_spam_blocked'


### PR DESCRIPTION
## Summary
This PR completes the Phase 1 foundation implementation for Improv Court with validated transitions, durable vote/session behavior, hardened API contracts, TTS abstraction, and overlay resilience improvements.

### What’s included
- State machine/property tests and transition guard coverage
- Restart recovery for interrupted running sessions
- Explicit `vote_closed` event + persisted vote snapshots at phase close
- API hardening with consistent error codes and negative/integration tests
- Pluggable TTS adapter (`noop` + `mock`) with non-fatal orchestration behavior
- Overlay UI improvements: loading state, error banner, reconnect backoff, phase progress bar
- New root `Makefile` with practical local/CI/dev commands
- Documentation updates (`README`, API docs, event taxonomy)

### Validation
- `npm run lint` ✅
- `npm test` ✅ (81 passing, 0 failing, 2 skipped)

### Notes
- Per request, no observability feature expansion was introduced.

## Closes
Closes #11
Closes #12
Closes #13
Closes #14
Closes #15
Closes #16

## Related
Refs #35