### PR TITLE
Add onboarding/catch-up panel for new viewers

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -173,6 +173,34 @@
                 text-shadow: 0 0 12px #88b4ff66;
             }
 
+            .catchup-shell {
+                margin-bottom: 12px;
+                border: 1px solid #2b2f41;
+                border-radius: 12px;
+                padding: 10px;
+                background: #121624;
+                display: grid;
+                gap: 8px;
+            }
+
+            .catchup-header {
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+                gap: 8px;
+            }
+
+            .catchup-summary {
+                font-size: 13px;
+                color: var(--text);
+                line-height: 1.4;
+            }
+
+            .catchup-meta {
+                font-size: 12px;
+                color: var(--muted);
+            }
+
             .loading {
                 opacity: 0.65;
                 cursor: wait;
@@ -366,6 +394,23 @@
                         <span id="activeSpeaker">Waiting for first turn…</span>
                     </div>
                     <div id="captionLine">Captions will appear here.</div>
+                </div>
+
+                <div class="catchup-shell">
+                    <div class="catchup-header">
+                        <h3 style="margin: 0; font-size: 14px">🧭 Case so far</h3>
+                        <button id="catchupToggle" type="button" class="badge" aria-expanded="true">
+                            Hide
+                        </button>
+                    </div>
+                    <div id="catchupBody">
+                        <div id="catchupSummary" class="catchup-summary">
+                            Waiting for opening statements…
+                        </div>
+                        <div id="catchupMeta" class="catchup-meta">
+                            phase: idle · Jury pending
+                        </div>
+                    </div>
                 </div>
 
                 <div id="feed"></div>

--- a/src/court/catchup.test.ts
+++ b/src/court/catchup.test.ts
@@ -1,0 +1,72 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    buildCaseSoFarSummary,
+    buildCatchupView,
+    juryStepFromPhase,
+} from './catchup.js';
+import type { CourtTurn } from '../types.js';
+
+function makeTurn(input: Partial<CourtTurn> & { id: string; dialogue: string }): CourtTurn {
+    return {
+        id: input.id,
+        sessionId: input.sessionId ?? 'sess-1',
+        turnNumber: input.turnNumber ?? 0,
+        speaker: input.speaker ?? 'chora',
+        role: input.role ?? 'judge',
+        phase: input.phase ?? 'openings',
+        dialogue: input.dialogue,
+        createdAt: input.createdAt ?? new Date().toISOString(),
+    };
+}
+
+test('buildCaseSoFarSummary prefers latest recap turn', () => {
+    const turns = [
+        makeTurn({ id: 't1', dialogue: 'Opening statement one.' }),
+        makeTurn({ id: 't2', dialogue: 'Recap: Key point from testimony.' }),
+        makeTurn({ id: 't3', dialogue: 'Cross examination detail.' }),
+    ];
+
+    const summary = buildCaseSoFarSummary(turns, ['t2']);
+    assert.equal(summary, 'Recap: Key point from testimony.');
+});
+
+test('buildCaseSoFarSummary falls back to recent stitched turns', () => {
+    const turns = [
+        makeTurn({ id: 't1', speaker: 'chora', dialogue: 'Opening one.' }),
+        makeTurn({ id: 't2', speaker: 'subrosa', dialogue: 'Counterpoint two.' }),
+        makeTurn({ id: 't3', speaker: 'thaum', dialogue: 'Witness detail three.' }),
+    ];
+
+    const summary = buildCaseSoFarSummary(turns, []);
+    assert.match(summary, /chora: Opening one\./);
+    assert.match(summary, /subrosa: Counterpoint two\./);
+    assert.match(summary, /thaum: Witness detail three\./);
+});
+
+test('juryStepFromPhase maps vote phases to jury-live status', () => {
+    assert.equal(juryStepFromPhase('verdict_vote'), 'Jury voting — verdict poll is live');
+    assert.equal(juryStepFromPhase('sentence_vote'), 'Jury voting — sentence poll is live');
+});
+
+test('buildCatchupView refreshes jury status when phase changes', () => {
+    const turns = [
+        makeTurn({ id: 't1', phase: 'witness_exam', dialogue: 'Witness statement.' }),
+    ];
+
+    const before = buildCatchupView({
+        phase: 'witness_exam',
+        turns,
+        recapTurnIds: [],
+    });
+    const after = buildCatchupView({
+        phase: 'verdict_vote',
+        turns,
+        recapTurnIds: [],
+    });
+
+    assert.equal(before.phaseLabel, 'witness_exam');
+    assert.equal(after.phaseLabel, 'verdict_vote');
+    assert.notEqual(before.juryStepStatus, after.juryStepStatus);
+    assert.equal(after.juryStepStatus, 'Jury voting — verdict poll is live');
+});

--- a/src/court/catchup.ts
+++ b/src/court/catchup.ts
@@ -1,0 +1,77 @@
+import type { CourtPhase, CourtTurn } from '../types.js';
+
+export interface CatchupView {
+    caseSoFar: string;
+    phaseLabel: string;
+    juryStepStatus: string;
+}
+
+function normalize(text: string, maxChars: number): string {
+    const compact = text.replace(/\s+/g, ' ').trim();
+    if (compact.length <= maxChars) {
+        return compact;
+    }
+    return `${compact.slice(0, Math.max(0, maxChars - 1)).trimEnd()}…`;
+}
+
+export function buildCaseSoFarSummary(
+    turns: CourtTurn[],
+    recapTurnIds: Iterable<string> | undefined,
+    maxChars = 220,
+): string {
+    const recapSet = new Set(recapTurnIds ?? []);
+    const latestRecap = [...turns]
+        .reverse()
+        .find(turn => recapSet.has(turn.id));
+
+    if (latestRecap?.dialogue) {
+        return normalize(latestRecap.dialogue, maxChars);
+    }
+
+    const recentTurns = turns.slice(-3);
+    if (recentTurns.length === 0) {
+        return 'The court has just opened. Waiting for opening statements.';
+    }
+
+    const stitched = recentTurns
+        .map(turn => `${turn.speaker}: ${turn.dialogue}`)
+        .join(' · ');
+    return normalize(stitched, maxChars);
+}
+
+export function juryStepFromPhase(phase: CourtPhase): string {
+    switch (phase) {
+        case 'case_prompt':
+            return 'Jury pending — court intro in progress';
+        case 'openings':
+            return 'Jury listening — opening statements';
+        case 'witness_exam':
+            return 'Jury observing witness examination';
+        case 'evidence_reveal':
+            return 'Jury reviewing evidence reveal';
+        case 'closings':
+            return 'Jury preparing for verdict vote';
+        case 'verdict_vote':
+            return 'Jury voting — verdict poll is live';
+        case 'sentence_vote':
+            return 'Jury voting — sentence poll is live';
+        case 'final_ruling':
+            return 'Jury complete — ruling delivered';
+        default: {
+            const _never: never = phase;
+            throw new Error(`Unknown phase: ${String(_never)}`);
+        }
+    }
+}
+
+export function buildCatchupView(input: {
+    phase: CourtPhase;
+    turns: CourtTurn[];
+    recapTurnIds?: Iterable<string>;
+}): CatchupView {
+    return {
+        caseSoFar: buildCaseSoFarSummary(input.turns, input.recapTurnIds),
+        phaseLabel: input.phase,
+        juryStepStatus: juryStepFromPhase(input.phase),
+    };
+}

--- a/src/public-catchup.test.ts
+++ b/src/public-catchup.test.ts
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+test('public index includes catch-up panel and toggle controls', () => {
+    const html = readFileSync(join(process.cwd(), 'public/index.html'), 'utf8');
+
+    assert.match(html, /id="catchupToggle"/);
+    assert.match(html, /id="catchupBody"/);
+    assert.match(html, /id="catchupSummary"/);
+    assert.match(html, /id="catchupMeta"/);
+    assert.match(html, /Case so far/i);
+});
+
+test('public app wires catch-up toggle telemetry and phase refresh behavior', () => {
+    const js = readFileSync(join(process.cwd(), 'public/app.js'), 'utf8');
+
+    assert.match(js, /function\s+setCatchupVisible\(/);
+    assert.match(js, /\[telemetry\]\s+catchup_panel_visibility/);
+    assert.match(js, /if \(payload\.type === 'phase_changed'\)/);
+    assert.match(js, /updateCatchupPanel\(activeSession\);/);
+});


### PR DESCRIPTION
## Summary
- add compact Case so far panel with current phase and jury-step status
- refresh catch-up context on snapshot, turn, recap, and phase-change events
- add hide/show toggle with aggregate-only visibility telemetry logging
- add tests for catch-up logic and static panel/telemetry wiring

## Validation
- npm run lint
- npm test

Closes #34
Refs #35