### PR TITLE
fix(dashboard): resolve React performance review findings

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,25 +1,105 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { Suspense, lazy, useCallback, useEffect, useState } from 'react';
 import { SessionMonitor } from './components/SessionMonitor';
-import { ModerationQueue } from './components/ModerationQueue';
-import { ManualControls } from './components/ManualControls';
-import { Analytics } from './components/Analytics';
 import { useSSE } from './hooks/useSSE';
-import type { CourtEvent } from './types';
+import { mapSessionToSnapshot } from './session-snapshot';
+import type { CourtEvent, SessionSnapshot } from './types';
+
+type DashboardTabId = 'monitor' | 'moderation' | 'controls' | 'analytics';
+
+const loadModerationQueue = () => import('./components/ModerationQueue');
+const loadManualControls = () => import('./components/ManualControls');
+const loadAnalytics = () => import('./components/Analytics');
+
+const ModerationQueue = lazy(async () => {
+    const module = await loadModerationQueue();
+    return { default: module.ModerationQueue };
+});
+
+const ManualControls = lazy(async () => {
+    const module = await loadManualControls();
+    return { default: module.ManualControls };
+});
+
+const Analytics = lazy(async () => {
+    const module = await loadAnalytics();
+    return { default: module.Analytics };
+});
+
+const TABS = [
+    { id: 'monitor', label: 'Session Monitor', icon: '📊' },
+    {
+        id: 'moderation',
+        label: 'Moderation Queue',
+        icon: '🛡️',
+        preload: loadModerationQueue,
+    },
+    {
+        id: 'controls',
+        label: 'Manual Controls',
+        icon: '🎛️',
+        preload: loadManualControls,
+    },
+    {
+        id: 'analytics',
+        label: 'Analytics',
+        icon: '📈',
+        preload: loadAnalytics,
+    },
+] as const satisfies ReadonlyArray<{
+    id: DashboardTabId;
+    label: string;
+    icon: string;
+    preload?: () => Promise<unknown>;
+}>;
+
+function TabFallback({ message }: { message: string }) {
+    return (
+        <div className='flex items-center justify-center py-12'>
+            <div className='text-gray-400'>{message}</div>
+        </div>
+    );
+}
 
 function App() {
-    const [activeTab, setActiveTab] = useState<
-        'monitor' | 'moderation' | 'controls' | 'analytics'
-    >('monitor');
+    const [activeTab, setActiveTab] = useState<DashboardTabId>('monitor');
     const [sessionId, setSessionId] = useState<string | null>(null);
+    const [sessionSnapshot, setSessionSnapshot] =
+        useState<SessionSnapshot | null>(null);
     const [events, setEvents] = useState<CourtEvent[]>([]);
+    const [sessionLookupLoading, setSessionLookupLoading] = useState(true);
+    const [sessionSnapshotLoading, setSessionSnapshotLoading] = useState(false);
 
     const handleSSEEvent = useCallback((event: CourtEvent) => {
         setEvents(prev => [...prev, event]);
     }, []);
 
-    const { connected, error } = useSSE(sessionId, handleSSEEvent);
+    const handleSSESnapshot = useCallback(
+        (payload: Record<string, unknown>) => {
+            const nextSnapshot = mapSessionToSnapshot({
+                session: payload.session,
+                turns: payload.turns,
+                recapTurnIds: payload.recapTurnIds,
+            });
+
+            if (!nextSnapshot) {
+                return;
+            }
+
+            setSessionSnapshot(nextSnapshot);
+            setSessionSnapshotLoading(false);
+        },
+        [],
+    );
+
+    const { connected, error } = useSSE(
+        sessionId,
+        handleSSEEvent,
+        handleSSESnapshot,
+    );
 
     useEffect(() => {
+        let cancelled = false;
+
         // Fetch current session on mount
         fetch('/api/court/sessions')
             .then(res => {
@@ -29,6 +109,10 @@ function App() {
                 return res.json();
             })
             .then(sessionsResponse => {
+                if (cancelled) {
+                    return;
+                }
+
                 let id: string | null = null;
 
                 if (
@@ -45,15 +129,118 @@ function App() {
                     setSessionId(id);
                 }
             })
-            .catch(err => console.error('Failed to fetch session:', err));
+            .catch(err => console.error('Failed to fetch session:', err))
+            .finally(() => {
+                if (!cancelled) {
+                    setSessionLookupLoading(false);
+                }
+            });
+
+        return () => {
+            cancelled = true;
+        };
     }, []);
 
-    const tabs = [
-        { id: 'monitor', label: 'Session Monitor', icon: '📊' },
-        { id: 'moderation', label: 'Moderation Queue', icon: '🛡️' },
-        { id: 'controls', label: 'Manual Controls', icon: '🎛️' },
-        { id: 'analytics', label: 'Analytics', icon: '📈' },
-    ] as const;
+    useEffect(() => {
+        if (!sessionId) {
+            setEvents([]);
+            setSessionSnapshot(null);
+            setSessionSnapshotLoading(false);
+            return;
+        }
+
+        let cancelled = false;
+        setEvents([]);
+        setSessionSnapshot(null);
+        setSessionSnapshotLoading(true);
+
+        fetch(`/api/court/sessions/${sessionId}`)
+            .then(res => {
+                if (!res.ok) {
+                    throw new Error(`Unexpected status ${res.status}`);
+                }
+
+                return res.json();
+            })
+            .then(data => {
+                if (cancelled) {
+                    return;
+                }
+
+                const nextSnapshot = mapSessionToSnapshot({
+                    session: data.session,
+                });
+
+                if (!nextSnapshot) {
+                    return;
+                }
+
+                setSessionSnapshot(current => current ?? nextSnapshot);
+            })
+            .catch(err =>
+                console.error('Failed to fetch session snapshot:', err),
+            )
+            .finally(() => {
+                if (!cancelled) {
+                    setSessionSnapshotLoading(false);
+                }
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [sessionId]);
+
+    const isSessionMonitorLoading =
+        sessionLookupLoading ||
+        (Boolean(sessionId) &&
+            sessionSnapshotLoading &&
+            sessionSnapshot === null);
+
+    const renderActiveTab = () => {
+        switch (activeTab) {
+            case 'monitor':
+                return (
+                    <SessionMonitor
+                        events={events}
+                        snapshot={sessionSnapshot}
+                        loading={isSessionMonitorLoading}
+                    />
+                );
+            case 'moderation':
+                return (
+                    <Suspense
+                        fallback={
+                            <TabFallback message='Loading moderation queue...' />
+                        }
+                    >
+                        <ModerationQueue events={events} />
+                    </Suspense>
+                );
+            case 'controls':
+                return (
+                    <Suspense
+                        fallback={
+                            <TabFallback message='Loading manual controls...' />
+                        }
+                    >
+                        <ManualControls sessionId={sessionId} />
+                    </Suspense>
+                );
+            case 'analytics':
+                return (
+                    <Suspense
+                        fallback={
+                            <TabFallback message='Loading analytics...' />
+                        }
+                    >
+                        <Analytics events={events} />
+                    </Suspense>
+                );
+            default:
+                return null;
+        }
+    };
 
     return (
         <div className='min-h-screen bg-gray-900 text-white'>
@@ -97,10 +284,20 @@ function App() {
             <nav className='bg-gray-800 border-b border-gray-700'>
                 <div className='container mx-auto px-4'>
                     <div className='flex gap-1'>
-                        {tabs.map(tab => (
+                        {TABS.map(tab => (
                             <button
                                 key={tab.id}
                                 onClick={() => setActiveTab(tab.id)}
+                                onMouseEnter={() => {
+                                    if (tab.preload) {
+                                        void tab.preload();
+                                    }
+                                }}
+                                onFocus={() => {
+                                    if (tab.preload) {
+                                        void tab.preload();
+                                    }
+                                }}
                                 className={`px-6 py-3 font-medium transition-colors ${
                                     activeTab === tab.id ?
                                         'bg-gray-900 text-primary-400 border-b-2 border-primary-400'
@@ -127,16 +324,7 @@ function App() {
 
             {/* Main Content */}
             <main className='container mx-auto px-4 py-6'>
-                {activeTab === 'monitor' && (
-                    <SessionMonitor events={events} sessionId={sessionId} />
-                )}
-                {activeTab === 'moderation' && (
-                    <ModerationQueue events={events} />
-                )}
-                {activeTab === 'controls' && (
-                    <ManualControls sessionId={sessionId} />
-                )}
-                {activeTab === 'analytics' && <Analytics events={events} />}
+                {renderActiveTab()}
             </main>
         </div>
     );

--- a/dashboard/src/components/Analytics.tsx
+++ b/dashboard/src/components/Analytics.tsx
@@ -7,56 +7,77 @@ interface AnalyticsProps {
 
 export function Analytics({ events }: AnalyticsProps) {
     const stats = useMemo(() => {
-        const byType = events.reduce(
-            (acc, event) => {
-                acc[event.type] = (acc[event.type] || 0) + 1;
-                return acc;
-            },
-            {} as Record<string, number>,
+        const byType: Record<string, number> = {};
+        const byPhase: Record<string, number> = {};
+        let votes = 0;
+        let statements = 0;
+        let recaps = 0;
+        let tokenBudgetApplied = 0;
+        let latestEstimatedTokens = 0;
+        let latestEstimatedCostUsd = 0;
+
+        for (const event of events) {
+            byType[event.type] = (byType[event.type] || 0) + 1;
+
+            if (event.type === 'phase_changed') {
+                const phase =
+                    typeof event.payload.phase === 'string' ?
+                        event.payload.phase
+                    :   '';
+                if (phase) {
+                    byPhase[phase] = (byPhase[phase] || 0) + 1;
+                }
+            }
+
+            if (event.type === 'vote_updated') {
+                votes += 1;
+            }
+
+            if (event.type === 'turn') {
+                statements += 1;
+            }
+
+            if (event.type === 'judge_recap_emitted') {
+                recaps += 1;
+            }
+
+            if (event.type === 'token_budget_applied') {
+                tokenBudgetApplied += 1;
+            }
+
+            if (event.type === 'session_token_estimate') {
+                if (
+                    typeof event.payload.cumulativeEstimatedTokens === 'number'
+                ) {
+                    latestEstimatedTokens =
+                        event.payload.cumulativeEstimatedTokens;
+                }
+
+                if (typeof event.payload.estimatedCostUsd === 'number') {
+                    latestEstimatedCostUsd = event.payload.estimatedCostUsd;
+                }
+            }
+        }
+
+        const sortedByType = Object.entries(byType).sort(
+            ([, leftCount], [, rightCount]) => rightCount - leftCount,
         );
 
-        const byPhase = events
-            .filter(e => e.type === 'phase_changed')
-            .reduce(
-                (acc, event) => {
-                    const phase = event.payload.phase as string;
-                    if (phase) acc[phase] = (acc[phase] || 0) + 1;
-                    return acc;
-                },
-                {} as Record<string, number>,
-            );
-
-        const votes = events.filter(e => e.type === 'vote_updated');
-        const statements = events.filter(e => e.type === 'turn');
-        const recaps = events.filter(e => e.type === 'judge_recap_emitted');
-        const tokenBudgetApplied = events.filter(
-            e => e.type === 'token_budget_applied',
+        const sortedByPhase = Object.entries(byPhase).sort(
+            ([, leftCount], [, rightCount]) => rightCount - leftCount,
         );
-        const tokenEstimates = events.filter(
-            e => e.type === 'session_token_estimate',
-        );
-
-        const latestEstimate = tokenEstimates[tokenEstimates.length - 1];
-        const latestEstimatedTokens =
-            typeof latestEstimate?.payload.cumulativeEstimatedTokens ===
-            'number' ?
-                latestEstimate.payload.cumulativeEstimatedTokens
-            :   0;
-        const latestEstimatedCostUsd =
-            typeof latestEstimate?.payload.estimatedCostUsd === 'number' ?
-                latestEstimate.payload.estimatedCostUsd
-            :   0;
 
         return {
             total: events.length,
-            byType,
-            byPhase,
-            votes: votes.length,
-            statements: statements.length,
-            recaps: recaps.length,
-            tokenBudgetApplied: tokenBudgetApplied.length,
+            byType: sortedByType,
+            byPhase: sortedByPhase,
+            votes,
+            statements,
+            recaps,
+            tokenBudgetApplied,
             latestEstimatedTokens,
             latestEstimatedCostUsd,
+            recentEvents: events.slice(-50).reverse(),
         };
     }, [events]);
 
@@ -111,30 +132,28 @@ export function Analytics({ events }: AnalyticsProps) {
                     Events by Type
                 </h2>
                 <div className='space-y-2'>
-                    {Object.entries(stats.byType)
-                        .sort(([, a], [, b]) => b - a)
-                        .map(([type, count]) => (
-                            <div key={type} className='flex items-center gap-3'>
-                                <div className='flex-1'>
-                                    <div className='flex justify-between mb-1'>
-                                        <span className='text-sm font-medium text-gray-300'>
-                                            {type}
-                                        </span>
-                                        <span className='text-sm text-gray-400'>
-                                            {count}
-                                        </span>
-                                    </div>
-                                    <div className='w-full bg-gray-700 rounded-full h-2'>
-                                        <div
-                                            className='bg-primary-500 h-2 rounded-full transition-all'
-                                            style={{
-                                                width: `${(count / stats.total) * 100}%`,
-                                            }}
-                                        />
-                                    </div>
+                    {stats.byType.map(([type, count]) => (
+                        <div key={type} className='flex items-center gap-3'>
+                            <div className='flex-1'>
+                                <div className='flex justify-between mb-1'>
+                                    <span className='text-sm font-medium text-gray-300'>
+                                        {type}
+                                    </span>
+                                    <span className='text-sm text-gray-400'>
+                                        {count}
+                                    </span>
+                                </div>
+                                <div className='w-full bg-gray-700 rounded-full h-2'>
+                                    <div
+                                        className='bg-primary-500 h-2 rounded-full transition-all'
+                                        style={{
+                                            width: `${(count / Math.max(stats.total, 1)) * 100}%`,
+                                        }}
+                                    />
                                 </div>
                             </div>
-                        ))}
+                        </div>
+                    ))}
                 </div>
             </div>
 
@@ -143,32 +162,31 @@ export function Analytics({ events }: AnalyticsProps) {
                 <h2 className='text-xl font-semibold mb-4 text-primary-400'>
                     Events by Phase
                 </h2>
-                {Object.keys(stats.byPhase).length === 0 ?
+                {stats.byPhase.length === 0 ?
                     <div className='text-gray-500 text-center py-4'>
                         No phase data available
                     </div>
                 :   <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
-                        {Object.entries(stats.byPhase)
-                            .sort(([, a], [, b]) => b - a)
-                            .map(([phase, count]) => (
-                                <div
-                                    key={phase}
-                                    className='bg-gray-700 rounded-lg p-4'
-                                >
-                                    <div className='text-sm text-gray-400'>
-                                        {phase}
-                                    </div>
-                                    <div className='text-2xl font-bold text-primary-400'>
-                                        {count}
-                                    </div>
-                                    <div className='text-xs text-gray-500 mt-1'>
-                                        {((count / stats.total) * 100).toFixed(
-                                            1,
-                                        )}
-                                        % of all events
-                                    </div>
+                        {stats.byPhase.map(([phase, count]) => (
+                            <div
+                                key={phase}
+                                className='bg-gray-700 rounded-lg p-4'
+                            >
+                                <div className='text-sm text-gray-400'>
+                                    {phase}
                                 </div>
-                            ))}
+                                <div className='text-2xl font-bold text-primary-400'>
+                                    {count}
+                                </div>
+                                <div className='text-xs text-gray-500 mt-1'>
+                                    {(
+                                        (count / Math.max(stats.total, 1)) *
+                                        100
+                                    ).toFixed(1)}
+                                    % of all events
+                                </div>
+                            </div>
+                        ))}
                     </div>
                 }
             </div>
@@ -179,41 +197,32 @@ export function Analytics({ events }: AnalyticsProps) {
                     Event Timeline
                 </h2>
                 <div className='space-y-1 max-h-96 overflow-y-auto'>
-                    {events.length === 0 ?
+                    {stats.total === 0 ?
                         <div className='text-gray-500 text-center py-4'>
                             No events recorded
                         </div>
-                    :   events
-                            .slice(-50)
-                            .reverse()
-                            .map(event => (
-                                <div
-                                    key={event.id}
-                                    className='flex items-center gap-3 py-2 px-3 hover:bg-gray-700 rounded transition-colors'
-                                >
-                                    <div className='text-xs text-gray-500 font-mono w-20'>
-                                        {new Date(
-                                            event.at,
-                                        ).toLocaleTimeString()}
-                                    </div>
-                                    <div className='flex-1'>
-                                        <span className='text-sm font-medium text-primary-300'>
-                                            {event.type}
-                                        </span>
-                                        {event.type === 'phase_changed' &&
-                                            event.payload.phase && (
-                                                <span className='ml-2 text-xs text-gray-400'>
-                                                    (
-                                                    {
-                                                        event.payload
-                                                            .phase as string
-                                                    }
-                                                    )
-                                                </span>
-                                            )}
-                                    </div>
+                    :   stats.recentEvents.map(event => (
+                            <div
+                                key={event.id}
+                                className='flex items-center gap-3 py-2 px-3 hover:bg-gray-700 rounded transition-colors'
+                            >
+                                <div className='text-xs text-gray-500 font-mono w-20'>
+                                    {new Date(event.at).toLocaleTimeString()}
                                 </div>
-                            ))
+                                <div className='flex-1'>
+                                    <span className='text-sm font-medium text-primary-300'>
+                                        {event.type}
+                                    </span>
+                                    {event.type === 'phase_changed' &&
+                                        event.payload.phase && (
+                                            <span className='ml-2 text-xs text-gray-400'>
+                                                ({event.payload.phase as string}
+                                                )
+                                            </span>
+                                        )}
+                                </div>
+                            </div>
+                        ))
                     }
                 </div>
             </div>

--- a/dashboard/src/components/ManualControls.tsx
+++ b/dashboard/src/components/ManualControls.tsx
@@ -2,6 +2,29 @@ import React, { useState } from 'react';
 
 const SESSION_RELOAD_DELAY_MS = 1500;
 
+const PHASE_OPTIONS = [
+    {
+        phase: 'witness_exam',
+        label: 'Start Witness Exam',
+        emoji: '👤',
+    },
+    {
+        phase: 'closings',
+        label: 'Start Closings',
+        emoji: '⚖️',
+    },
+    {
+        phase: 'verdict_vote',
+        label: 'Start Verdict Vote',
+        emoji: '🗳️',
+    },
+    {
+        phase: 'final_ruling',
+        label: 'Final Ruling',
+        emoji: '📜',
+    },
+] as const;
+
 interface ManualControlsProps {
     sessionId: string | null;
 }
@@ -23,11 +46,14 @@ export function ManualControls({ sessionId }: ManualControlsProps) {
         setMessage(null);
 
         try {
-            const response = await fetch(`/api/court/sessions/${sessionId}/phase`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ phase: targetPhase }),
-            });
+            const response = await fetch(
+                `/api/court/sessions/${sessionId}/phase`,
+                {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ phase: targetPhase }),
+                },
+            );
 
             if (!response.ok) {
                 throw new Error(`Action failed: ${response.statusText}`);
@@ -69,10 +95,7 @@ export function ManualControls({ sessionId }: ManualControlsProps) {
             });
 
             // Reload page to connect to new session
-            setTimeout(
-                () => window.location.reload(),
-                SESSION_RELOAD_DELAY_MS,
-            );
+            setTimeout(() => window.location.reload(), SESSION_RELOAD_DELAY_MS);
         } catch (err) {
             setMessage({ type: 'error', text: (err as Error).message });
         } finally {
@@ -118,28 +141,7 @@ export function ManualControls({ sessionId }: ManualControlsProps) {
                         Phase Control
                     </h2>
                     <div className='grid grid-cols-1 md:grid-cols-2 gap-3'>
-                        {[
-                            {
-                                phase: 'witness_exam',
-                                label: 'Start Witness Exam',
-                                emoji: '👤',
-                            },
-                            {
-                                phase: 'closings',
-                                label: 'Start Closings',
-                                emoji: '⚖️',
-                            },
-                            {
-                                phase: 'verdict_vote',
-                                label: 'Start Verdict Vote',
-                                emoji: '🗳️',
-                            },
-                            {
-                                phase: 'final_ruling',
-                                label: 'Final Ruling',
-                                emoji: '📜',
-                            },
-                        ].map(({ phase, label, emoji }) => (
+                        {PHASE_OPTIONS.map(({ phase, label, emoji }) => (
                             <button
                                 key={phase}
                                 onClick={() => handleAdvancePhase(phase)}

--- a/dashboard/src/session-snapshot.ts
+++ b/dashboard/src/session-snapshot.ts
@@ -1,0 +1,149 @@
+import type { SessionSnapshot, TranscriptEntry, VoteCount } from './types';
+
+const DEFAULT_MAX_WITNESS_STATEMENTS = 3;
+const DEFAULT_RECAP_INTERVAL = 2;
+
+type UnknownRecord = Record<string, unknown>;
+
+interface SessionSnapshotInput {
+    session: unknown;
+    turns?: unknown;
+    recapTurnIds?: unknown;
+}
+
+function isRecord(value: unknown): value is UnknownRecord {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asRecord(value: unknown): UnknownRecord {
+    return isRecord(value) ? value : {};
+}
+
+function asString(value: unknown): string | null {
+    return typeof value === 'string' ? value : null;
+}
+
+function asNumber(value: unknown, fallback = 0): number {
+    return typeof value === 'number' && Number.isFinite(value) ?
+            value
+        :   fallback;
+}
+
+function asPositiveNumber(value: unknown, fallback: number): number {
+    return typeof value === 'number' && Number.isFinite(value) && value > 0 ?
+            value
+        :   fallback;
+}
+
+function asStringArray(value: unknown): string[] {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+
+    return value.filter((item): item is string => typeof item === 'string');
+}
+
+function buildTranscript(
+    turnsInput: unknown,
+    recapTurnIds: Set<string>,
+): TranscriptEntry[] {
+    if (!Array.isArray(turnsInput)) {
+        return [];
+    }
+
+    const transcript: TranscriptEntry[] = [];
+
+    for (const turn of turnsInput) {
+        if (!isRecord(turn)) {
+            continue;
+        }
+
+        const turnId = asString(turn.id);
+        const speaker = asString(turn.speaker) ?? 'Unknown';
+        const content = asString(turn.dialogue) ?? asString(turn.content) ?? '';
+        const timestamp =
+            asString(turn.createdAt) ??
+            asString(turn.at) ??
+            new Date().toISOString();
+
+        transcript.push({
+            speaker,
+            content,
+            timestamp,
+            isRecap: turnId ? recapTurnIds.has(turnId) : false,
+        });
+    }
+
+    return transcript;
+}
+
+function buildVerdictVotes(metadata: UnknownRecord): VoteCount {
+    const verdictVotes = asRecord(metadata.verdictVotes);
+    const guilty = asNumber(verdictVotes.guilty);
+    const innocent =
+        asNumber(verdictVotes.not_guilty) || asNumber(verdictVotes.not_liable);
+    const total = Object.values(verdictVotes).reduce(
+        (sum, value) => sum + asNumber(value),
+        0,
+    );
+
+    return {
+        guilty,
+        innocent,
+        total,
+    };
+}
+
+function buildWitnessCaps(
+    metadata: UnknownRecord,
+): SessionSnapshot['witnessCaps'] {
+    const witnessCaps = asRecord(metadata.witnessCaps);
+
+    return {
+        witness1: asNumber(witnessCaps.witness1),
+        witness2: asNumber(witnessCaps.witness2),
+    };
+}
+
+function buildConfig(metadata: UnknownRecord): SessionSnapshot['config'] {
+    return {
+        maxWitnessStatements: asPositiveNumber(
+            metadata.maxWitnessStatements,
+            DEFAULT_MAX_WITNESS_STATEMENTS,
+        ),
+        recapInterval: asPositiveNumber(
+            metadata.recapInterval,
+            DEFAULT_RECAP_INTERVAL,
+        ),
+    };
+}
+
+export function mapSessionToSnapshot(
+    input: SessionSnapshotInput,
+): SessionSnapshot | null {
+    const session = asRecord(input.session);
+    const sessionId = asString(session.id);
+    const phase = asString(session.phase);
+
+    if (!sessionId || !phase) {
+        return null;
+    }
+
+    const metadata = asRecord(session.metadata);
+    const recapTurnIds = new Set(
+        asStringArray(input.recapTurnIds ?? metadata.recapTurnIds),
+    );
+    const turns = input.turns ?? session.turns ?? [];
+
+    return {
+        sessionId,
+        phase,
+        transcript: buildTranscript(turns, recapTurnIds),
+        votes: {
+            verdict: buildVerdictVotes(metadata),
+        },
+        recapCount: recapTurnIds.size,
+        witnessCaps: buildWitnessCaps(metadata),
+        config: buildConfig(metadata),
+    };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "dependencies": {
                 "dotenv": "^17.2.3",
                 "express": "^4.21.2",
+                "express-rate-limit": "^8.2.1",
                 "postgres": "^3.4.5",
                 "react": "^18.3.1",
                 "react-dom": "^18.3.1"
@@ -2035,6 +2036,7 @@
             "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
             "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
@@ -2074,6 +2076,24 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/express-rate-limit": {
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+            "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+            "license": "MIT",
+            "dependencies": {
+                "ip-address": "10.0.1"
+            },
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/express-rate-limit"
+            },
+            "peerDependencies": {
+                "express": ">= 4.11"
             }
         },
         "node_modules/fast-glob": {
@@ -2349,6 +2369,15 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "license": "ISC"
+        },
+        "node_modules/ip-address": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+            "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
+            }
         },
         "node_modules/ipaddr.js": {
             "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "dependencies": {
         "dotenv": "^17.2.3",
         "express": "^4.21.2",
+        "express-rate-limit": "^8.2.1",
         "postgres": "^3.4.5",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1",
-        "express-rate-limit": "^8.2.1"
+        "react-dom": "^18.3.1"
     },
     "devDependencies": {
         "@types/express": "^4.17.21",


### PR DESCRIPTION
## Summary
- lazy-load non-default dashboard tabs (`ModerationQueue`, `ManualControls`, `Analytics`) via `React.lazy` + `Suspense`
- add intent-based preloading on tab hover/focus to keep tab navigation responsive
- centralize session snapshot state in `App` and normalize payload mapping in new `dashboard/src/session-snapshot.ts`
- consume SSE `snapshot` payloads in `useSSE` instead of dropping them
- refactor `SessionMonitor` to consume shared snapshot props and remove duplicate snapshot fetch path
- optimize `ModerationQueue` by incrementally processing only new events and memoizing queue stats/filtering
- optimize `Analytics` with single-pass aggregation and memoized sorted entries/timeline
- hoist static phase options in `ManualControls`

## Verification
- `npm run test` ✅ (130 passed, 0 failed, 2 skipped)
- `npm run build:dashboard` ✅

## Notes
- `package-lock.json` now includes `express-rate-limit` resolution so test/runtime dependency resolution is consistent in this environment.