### PR TITLE
feat: court flow redesign — structured witness exam, objections, random events, pacing

### DIFF
--- a/docs/plans/2026-02-28-court-flow-redesign-design.md
+++ b/docs/plans/2026-02-28-court-flow-redesign-design.md
@@ -124,7 +124,7 @@ Categories and intent:
 | `src/court/phases/session-flow.ts` | Rewrite `runWitnessExamPhase`; update `PAUSE_MS` constants |
 | `src/court/phases/witness-script.ts` | New — `buildWitnessScripts()`, `WitnessScript` type |
 | `src/court/phases/random-events.ts` | New — event catalogue, `checkRandomEvent()` |
-| `src/court/phases/objections.ts` | New — `checkObjection()` (organic flag check + classifier call + judge ruling) |
+| `src/court/phases/objections.ts` | New — `handleObjectionRound()` (organic flag check + classifier call + judge ruling) |
 | `src/llm/client.ts` | Rewrite `mockReply()` with randomised versatile lines |
 | Test files | New unit tests for script builder, random events, objection classifier |
 

--- a/docs/plans/2026-02-28-court-flow-redesign-design.md
+++ b/docs/plans/2026-02-28-court-flow-redesign-design.md
@@ -1,0 +1,135 @@
+# Design: Court Flow Redesign
+
+**Date:** 2026-02-28
+**Status:** Approved
+
+## Overview
+
+Redesign the witness examination phase and supporting systems to produce more structured, dramatically satisfying trial proceedings. Fixes the current judge-opens-questioning bug, adds variable-length exchanges via a script builder, introduces probability-based random events, implements layered LLM-driven objections, increases pacing delays for Twitch viewing, and replaces brittle fixed mock dialogue with versatile fallback lines.
+
+## Section 1: Witness Exam Restructure
+
+Replace the current `runWitnessExamPhase` flow (judge asks → witness → prosecutor → defense) with a proper direct/cross structure.
+
+**Per witness:**
+
+```
+1. Bailiff announces: "[DisplayName], [role/occupation], please take the stand."
+
+2. Direct examination — 3–7 rounds (drawn by script builder at phase start):
+   Each round:
+   ├─ Prosecutor asks a question
+   ├─ Witness answers
+   ├─ [Random event check — can fire here]
+   ├─ [Objection check: defense organic + classifier]
+   │   └─ Judge ALWAYS rules if objection fired (sustain/overrule + 1 sentence)
+   └─ [Judge interrupt: 10–12% chance — clarification or jury instruction; skips objection slot]
+
+3. Cross-examination — 2–5 rounds (drawn by script builder at phase start):
+   Each round:
+   ├─ Defense asks a question
+   ├─ Witness answers
+   ├─ [Random event check — can fire here]
+   ├─ [Objection check: prosecutor organic + classifier]
+   │   └─ Judge ALWAYS rules if objection fired (sustain/overrule + 1 sentence)
+   └─ [Judge interrupt: 10–12% chance — clarification or jury instruction; skips objection slot]
+```
+
+**Rules:**
+- Judge never opens witness questioning
+- Bailiff introduces each witness by `displayName` (from `AgentConfig`)
+- No objection check after any judge turn (interrupt or ruling)
+- Judge always rules on any detected objection
+
+## Section 2: Script Builder
+
+Called once at the start of `runWitnessExamPhase`. Produces a pre-drawn plan for all witnesses so the structure is determined up-front and logged.
+
+```ts
+interface WitnessScript {
+    directRounds: number;  // drawn: 3–7
+    crossRounds: number;   // drawn: 2–5
+}
+
+function buildWitnessScripts(witnessCount: number): WitnessScript[]
+```
+
+Each witness gets independently rolled values. The full plan is logged at phase start so the session structure is visible in server output.
+
+## Section 3: Random Events
+
+A catalogue of named events checked once per round after the witness answer. Each has a probability and a designated speaker role. Only one event fires per round.
+
+| Event ID | Probability | Speaker | Description |
+|---|---|---|---|
+| `witness_outburst` | 12% | witness | Witness goes off-script with an emotional or bizarre interjection |
+| `dramatic_revelation` | 8% | witness | Witness blurts something that reframes the whole case |
+| `bailiff_interruption` | 8% | bailiff | Bailiff intervenes due to courtroom disorder |
+| `gallery_disruption` | 6% | judge | Judge restores order after audience chaos |
+| `evidence_challenged` | 10% | prosecutor or defense | Opposing counsel challenges the evidentiary basis of a question |
+
+Events generate one extra `generateBudgetedTurn` with a role-appropriate `userInstruction`, then proceedings resume normally. Events fire during both direct and cross rounds.
+
+## Section 4: Objections (Layered — Option C)
+
+Two mechanisms work in tandem. No objection check fires after any judge turn.
+
+### Organic (B) — attorney self-trigger
+The opposing attorney's system prompt during witness exam includes:
+
+> *"If the preceding dialogue gives you clear legal grounds to object — hearsay, speculation, badgering, or a leading question — begin your turn with `OBJECTION: [type]`. Otherwise proceed normally with your next question or rebuttal."*
+
+The generated turn either becomes an objection or normal dialogue; no extra API call required.
+
+### Classifier (A) — safety net
+After each attorney question and witness answer (not after judge turns), a lightweight secondary LLM call:
+
+> *"Does the following dialogue give opposing counsel grounds to object? Respond only: `yes: <type>` or `no`."*
+
+If the classifier returns `yes` and organic did not already fire an objection this round, the opposing attorney generates an objection turn.
+
+### Judge ruling
+Always generated when an objection is detected (from either mechanism). One turn:
+- Speaker: judge
+- `userInstruction`: *"Rule on this objection: sustained or overruled. One sentence, then move proceedings forward."*
+
+## Section 5: Pacing
+
+All delays increased for comfortable Twitch viewing pace.
+
+| Constant | Before | After |
+|---|---|---|
+| `witnessBetweenTurns` | 600 ms | 2,500 ms |
+| `witnessBetweenCycles` | 800 ms | 3,000 ms |
+| `openingBetweenSides` | 900 ms | 2,000 ms |
+| `casePromptAfterCue` | 1,200 ms | 2,000 ms |
+| `recapLeadIn` | 600 ms | 1,500 ms |
+| `closingBetweenSides` | 800 ms | 2,000 ms |
+
+## Section 6: Mock Dialogue Variety
+
+`mockReply()` in `src/llm/client.ts` is rewritten to select randomly from 5+ strings per category. All lines are intentionally generic — they must work for any case topic without referencing specific facts. Absurd tone is preserved; specificity is not.
+
+Categories and intent:
+- **opening/statement** — broad declarations about evidence, truth, chaos
+- **witness/testimony** — vague sensory observations that could apply to any incident
+- **closing** — philosophical summations about justice and human nature
+- **ruling/verdict** — judicial pronouncements on guilt, ambiguity, or dramatic irony
+- **default** — catch-all procedural filler that sounds plausible in any phase
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `src/court/phases/session-flow.ts` | Rewrite `runWitnessExamPhase`; update `PAUSE_MS` constants |
+| `src/court/phases/witness-script.ts` | New — `buildWitnessScripts()`, `WitnessScript` type |
+| `src/court/phases/random-events.ts` | New — event catalogue, `checkRandomEvent()` |
+| `src/court/phases/objections.ts` | New — `checkObjection()` (organic flag check + classifier call + judge ruling) |
+| `src/llm/client.ts` | Rewrite `mockReply()` with randomised versatile lines |
+| Test files | New unit tests for script builder, random events, objection classifier |
+
+## Out of Scope
+
+- Twitch channel-points objection trigger — future work
+- Overlay/renderer visual changes (gavel slam, objection stamp) — separate pass
+- Changing `CourtPhase` values or session state shape

--- a/docs/plans/2026-02-28-court-flow-redesign.md
+++ b/docs/plans/2026-02-28-court-flow-redesign.md
@@ -1,0 +1,889 @@
+# Court Flow Redesign Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Restructure witness examination to follow proper direct/cross order, add a script builder for variable exchange counts, inject probability-based random events, implement layered LLM-driven objections, increase pacing delays, and replace fixed mock dialogue with versatile randomised fallbacks.
+
+**Architecture:** Six independent modules (Tasks 1–5) are integrated into a rewritten `runWitnessExamPhase` in Task 6. Each new module lives in `src/court/phases/` and is independently testable. Random events and objection detection each accept an injectable `rng` parameter so they are deterministic in tests.
+
+**Tech Stack:** TypeScript ESM, `node --import tsx --test` test runner (`npm test`), Node built-in `node:test` / `node:assert/strict`.
+
+---
+
+### Task 1: Mock Dialogue Variety
+
+Fix the brittle single-string mock fallback that repeats identical lines on every rate-limited call. Each category gets 5–6 generic lines broad enough to fit any case topic.
+
+**Files:**
+- Modify: `src/llm/client.ts:54-68` (the `mockReply` function)
+- Modify: `src/llm/client.test.ts:83` (loosen the "Ladies and gentlemen" assertion)
+
+**Step 1: Update the test assertion first**
+
+Open `src/llm/client.test.ts`. Line 83 currently reads:
+
+```ts
+assert.match(output, /Ladies and gentlemen/i);
+```
+
+Replace it with:
+
+```ts
+assert.ok(output.length > 0, 'Expected non-empty fallback text when model content is empty');
+```
+
+**Step 2: Run the existing tests to confirm they pass**
+
+```bash
+npm test
+```
+
+Expected: all tests pass (the assertion is now looser, nothing broke).
+
+**Step 3: Replace `mockReply` in `src/llm/client.ts`**
+
+Find the `mockReply` function (lines 54–68) and replace it entirely:
+
+```ts
+const MOCK_LINES: Record<string, string[]> = {
+    'opening|statement': [
+        'The facts in this case are stranger than fiction, and the fiction is not great either. We intend to prove every last strange bit of it.',
+        'The evidence will speak for itself — loudly, incoherently, and with unusual conviction.',
+        'What you are about to hear is either a crime or a misunderstanding of historic proportions. Possibly both.',
+        'The prosecution will demonstrate, beyond reasonable doubt, that something happened. The exact nature of that something will become abundantly clear.',
+        'We ask only that you keep an open mind — and perhaps a strong stomach.',
+        'The defense maintains our client is innocent, and also maintains several other positions that will be revealed at the worst possible moment.',
+    ],
+    'witness|testimony|cross': [
+        'I can state with certainty that I observed something. The details are fuzzy, but the certainty is very high.',
+        'At the time I thought nothing of it. In retrospect I should have thought quite a lot of it.',
+        'I was present. I was observing. What I observed is what you might call difficult to categorize.',
+        'Everything I am about to say is accurate to the best of my recollection, which is doing its best.',
+        'There was an incident. I was adjacent to it. My proximity was noted by several parties, including myself.',
+        'I remember it clearly: there was a moment, and I was in it. The moment was notable. That is my testimony.',
+    ],
+    'closing': [
+        'The evidence has spoken. It has spoken at length, somewhat repetitively, and with great emotional commitment.',
+        'We ask you to weigh the facts — not the feelings, not the drama, not the seventeen things that went unexpectedly sideways.',
+        'One truth remains: something happened, someone did it, and this court must decide what happens next.',
+        'The defense rests — on the bedrock of reasonable doubt and a sincere belief that this has all gone far enough.',
+        'Justice demands a verdict. Logic demands clarity. The circumstances demand a stiff drink and a long lie-down.',
+        'I leave you with this: whatever you decide, decide it with the full weight of your conscience and at least two of your five senses.',
+    ],
+    'ruling|verdict': [
+        'On the matter before this court, I have considered the evidence, the arguments, and my own rising blood pressure. The verdict stands.',
+        'This court finds the evidence compelling in ways that are difficult to articulate but impossible to ignore.',
+        'I have heard enough. The court has heard enough. The court reporter has definitely heard enough.',
+        'The ruling of this court is final. The chaos leading to it was anything but. Proceedings are concluded.',
+        'After careful deliberation — I wrote things down — this court delivers its judgment.',
+        'This court has seen many things. Most of them were other cases. Nevertheless, a verdict is reached.',
+    ],
+};
+
+const MOCK_LINES_DEFAULT = [
+    'Noted. The court acknowledges the point and invites us all to move forward with cautious optimism.',
+    'Order. We proceed. Whatever just happened, we proceed from it.',
+    'The record reflects the current state of affairs. The current state of affairs is noted.',
+    'This court will take that under advisement. We advise ourselves to continue.',
+    'The relevant determination having been made, proceedings continue.',
+    'So noted. The court is, as always, moving forward.',
+];
+
+function pickRandom<T>(arr: T[]): T {
+    return arr[Math.floor(Math.random() * arr.length)]!;
+}
+
+function mockReply(prompt: string): string {
+    for (const [pattern, lines] of Object.entries(MOCK_LINES)) {
+        if (new RegExp(pattern, 'i').test(prompt)) {
+            return pickRandom(lines);
+        }
+    }
+    return pickRandom(MOCK_LINES_DEFAULT);
+}
+```
+
+**Step 4: Run the tests again**
+
+```bash
+npm test
+```
+
+Expected: all tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/llm/client.ts src/llm/client.test.ts
+git commit -m "feat: randomise mock dialogue fallback with versatile category lines"
+```
+
+---
+
+### Task 2: Pacing Constants
+
+Increase all inter-turn delays for comfortable Twitch viewing pace.
+
+**Files:**
+- Modify: `src/court/phases/session-flow.ts:25-32`
+
+**Step 1: Update `PAUSE_MS` in `src/court/phases/session-flow.ts`**
+
+Find the `PAUSE_MS` object (lines 25–32) and replace:
+
+```ts
+const PAUSE_MS = {
+    casePromptAfterCue: 2_000,
+    openingBetweenSides: 2_000,
+    witnessBetweenTurns: 2_500,
+    witnessBetweenCycles: 3_000,
+    recapLeadIn: 1_500,
+    closingBetweenSides: 2_000,
+} as const;
+```
+
+**Step 2: Run tests**
+
+```bash
+npm test
+```
+
+Expected: all tests pass (pacing constants are not directly tested).
+
+**Step 3: Commit**
+
+```bash
+git add src/court/phases/session-flow.ts
+git commit -m "feat: increase pacing delays for Twitch viewing comfort"
+```
+
+---
+
+### Task 3: Witness Script Builder
+
+A pure function that draws variable round counts per witness at phase start, keeping structure deterministic once drawn.
+
+**Files:**
+- Create: `src/court/phases/witness-script.ts`
+- Create: `src/court/phases/witness-script.test.ts`
+
+**Step 1: Write the failing test**
+
+Create `src/court/phases/witness-script.test.ts`:
+
+```ts
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildWitnessScripts } from './witness-script.js';
+
+describe('buildWitnessScripts', () => {
+    it('returns one script per witness', () => {
+        const scripts = buildWitnessScripts(3);
+        assert.equal(scripts.length, 3);
+    });
+
+    it('direct rounds are in range 3–7', () => {
+        for (let i = 0; i < 50; i++) {
+            const [script] = buildWitnessScripts(1);
+            assert.ok(script!.directRounds >= 3 && script!.directRounds <= 7,
+                `directRounds out of range: ${script!.directRounds}`);
+        }
+    });
+
+    it('cross rounds are in range 2–5', () => {
+        for (let i = 0; i < 50; i++) {
+            const [script] = buildWitnessScripts(1);
+            assert.ok(script!.crossRounds >= 2 && script!.crossRounds <= 5,
+                `crossRounds out of range: ${script!.crossRounds}`);
+        }
+    });
+
+    it('witnesses get independent rolls', () => {
+        const scripts = buildWitnessScripts(20);
+        const directCounts = new Set(scripts.map(s => s.directRounds));
+        // With 20 witnesses and 5 possible values (3-7), very likely to see at least 2 distinct values
+        assert.ok(directCounts.size > 1, 'All 20 witnesses got identical directRounds — extremely unlikely if random');
+    });
+
+    it('returns empty array for 0 witnesses', () => {
+        assert.deepEqual(buildWitnessScripts(0), []);
+    });
+});
+```
+
+**Step 2: Run tests to confirm failure**
+
+```bash
+npm test
+```
+
+Expected: FAIL — "Cannot find module './witness-script.js'"
+
+**Step 3: Implement `src/court/phases/witness-script.ts`**
+
+```ts
+export interface WitnessScript {
+    directRounds: number; // 3–7
+    crossRounds: number;  // 2–5
+}
+
+export function buildWitnessScripts(witnessCount: number): WitnessScript[] {
+    return Array.from({ length: witnessCount }, () => ({
+        directRounds: Math.floor(Math.random() * 5) + 3,
+        crossRounds: Math.floor(Math.random() * 4) + 2,
+    }));
+}
+```
+
+**Step 4: Run tests to confirm pass**
+
+```bash
+npm test
+```
+
+Expected: all tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/court/phases/witness-script.ts src/court/phases/witness-script.test.ts
+git commit -m "feat: witness script builder draws variable round counts per witness"
+```
+
+---
+
+### Task 4: Random Events
+
+A catalogue of named courtroom events with probability weights. Checked once per round after the witness answer. Only one event fires per round.
+
+**Files:**
+- Create: `src/court/phases/random-events.ts`
+- Create: `src/court/phases/random-events.test.ts`
+
+**Step 1: Write the failing test**
+
+Create `src/court/phases/random-events.test.ts`:
+
+```ts
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { checkRandomEvent, RANDOM_EVENTS } from './random-events.js';
+
+describe('checkRandomEvent', () => {
+    it('returns null when rng always returns 1.0 (above all probabilities)', () => {
+        const result = checkRandomEvent(() => 1.0);
+        assert.equal(result, null);
+    });
+
+    it('returns an event when rng always returns 0.0 (below all probabilities)', () => {
+        const result = checkRandomEvent(() => 0.0);
+        assert.ok(result !== null);
+        assert.ok(typeof result.id === 'string');
+        assert.ok(typeof result.userInstruction === 'string');
+    });
+
+    it('returns at most one event per call', () => {
+        let callCount = 0;
+        const rng = () => {
+            callCount++;
+            return 0.0; // fires everything
+        };
+        const result = checkRandomEvent(rng);
+        // Result is a single event or null — not an array
+        assert.ok(result === null || typeof result.id === 'string');
+    });
+
+    it('all RANDOM_EVENTS have required fields', () => {
+        for (const event of RANDOM_EVENTS) {
+            assert.ok(typeof event.id === 'string', `event.id missing: ${JSON.stringify(event)}`);
+            assert.ok(typeof event.probability === 'number');
+            assert.ok(event.probability > 0 && event.probability < 1);
+            assert.ok(typeof event.speaker === 'string');
+            assert.ok(typeof event.userInstruction === 'string');
+        }
+    });
+});
+```
+
+**Step 2: Run tests to confirm failure**
+
+```bash
+npm test
+```
+
+Expected: FAIL — "Cannot find module './random-events.js'"
+
+**Step 3: Implement `src/court/phases/random-events.ts`**
+
+```ts
+export type EventSpeaker = 'witness' | 'bailiff' | 'judge' | 'opposing_counsel';
+
+export interface RandomEvent {
+    id: string;
+    probability: number;
+    speaker: EventSpeaker;
+    userInstruction: string;
+}
+
+export const RANDOM_EVENTS: RandomEvent[] = [
+    {
+        id: 'witness_outburst',
+        probability: 0.12,
+        speaker: 'witness',
+        userInstruction:
+            'Have an emotional or bizarre outburst relevant to the case. Stay in character but go off-script in an unexpected way that reveals something about your relationship to the events.',
+    },
+    {
+        id: 'dramatic_revelation',
+        probability: 0.08,
+        speaker: 'witness',
+        userInstruction:
+            'Blurt out an unexpected detail that reframes the entire case. Make it dramatic, specific to the case topic, and something neither side was expecting.',
+    },
+    {
+        id: 'bailiff_interruption',
+        probability: 0.08,
+        speaker: 'bailiff',
+        userInstruction:
+            'Briefly interrupt proceedings to address a minor courtroom disturbance. Keep it short, procedural, and mildly absurd.',
+    },
+    {
+        id: 'gallery_disruption',
+        probability: 0.06,
+        speaker: 'judge',
+        userInstruction:
+            'Restore order after the public gallery disrupts proceedings. Be authoritative and slightly exasperated. One or two sentences.',
+    },
+    {
+        id: 'evidence_challenged',
+        probability: 0.10,
+        speaker: 'opposing_counsel',
+        userInstruction:
+            'Challenge the evidentiary basis of the preceding question or answer. Be specific about what you are challenging and why it is inadmissible or misleading.',
+    },
+];
+
+/**
+ * Checks whether a random event fires this round.
+ * Accepts an injectable `rng` for deterministic testing.
+ * Returns at most one event; returns null if none fire.
+ */
+export function checkRandomEvent(rng: () => number = Math.random): RandomEvent | null {
+    // Shuffle catalogue so higher-probability events don't always win on ties
+    const shuffled = [...RANDOM_EVENTS].sort(() => rng() - 0.5);
+    for (const event of shuffled) {
+        if (rng() < event.probability) {
+            return event;
+        }
+    }
+    return null;
+}
+```
+
+**Step 4: Run tests to confirm pass**
+
+```bash
+npm test
+```
+
+Expected: all tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/court/phases/random-events.ts src/court/phases/random-events.test.ts
+git commit -m "feat: random event catalogue with injectable rng for deterministic testing"
+```
+
+---
+
+### Task 5: Objection Detection and Handling
+
+Two-layer objection system: organic self-trigger detection (string parse, zero cost) and a lightweight LLM classifier call as safety net. Judge always rules when an objection is detected.
+
+**Files:**
+- Create: `src/court/phases/objections.ts`
+- Create: `src/court/phases/objections.test.ts`
+
+**Step 1: Write the failing tests**
+
+Create `src/court/phases/objections.test.ts`:
+
+```ts
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { detectOrganicObjection, parseClassifierResponse } from './objections.js';
+
+describe('detectOrganicObjection', () => {
+    it('detects OBJECTION: at start of dialogue', () => {
+        const result = detectOrganicObjection('OBJECTION: hearsay. That is inadmissible.');
+        assert.equal(result, 'hearsay. That is inadmissible.');
+    });
+
+    it('is case-insensitive', () => {
+        const result = detectOrganicObjection('Objection: leading question.');
+        assert.equal(result, 'leading question.');
+    });
+
+    it('returns null when dialogue does not start with OBJECTION:', () => {
+        assert.equal(detectOrganicObjection('I strongly disagree with that characterisation.'), null);
+    });
+
+    it('returns null for empty string', () => {
+        assert.equal(detectOrganicObjection(''), null);
+    });
+
+    it('does not match OBJECTION mid-sentence', () => {
+        assert.equal(detectOrganicObjection('Counsel raises an OBJECTION: hearsay.'), null);
+    });
+});
+
+describe('parseClassifierResponse', () => {
+    it('returns objection type for yes: response', () => {
+        assert.equal(parseClassifierResponse('yes: hearsay'), 'hearsay');
+    });
+
+    it('is case-insensitive', () => {
+        assert.equal(parseClassifierResponse('Yes: Speculation'), 'Speculation');
+    });
+
+    it('returns null for no', () => {
+        assert.equal(parseClassifierResponse('no'), null);
+    });
+
+    it('returns null for empty string', () => {
+        assert.equal(parseClassifierResponse(''), null);
+    });
+});
+```
+
+**Step 2: Run tests to confirm failure**
+
+```bash
+npm test
+```
+
+Expected: FAIL — "Cannot find module './objections.js'"
+
+**Step 3: Implement `src/court/phases/objections.ts`**
+
+```ts
+import type { AgentId, CourtRole, CourtSession } from '../../types.js';
+import type { CourtSessionStore } from '../../store/session-store.js';
+import { llmGenerate } from '../../llm/client.js';
+import type { GenerateBudgetedTurn } from './session-flow.js';
+
+/**
+ * Checks if the attorney self-triggered an objection by beginning dialogue with "OBJECTION:".
+ * Returns the text after "OBJECTION:" or null.
+ */
+export function detectOrganicObjection(dialogue: string): string | null {
+    const match = dialogue.match(/^OBJECTION:\s*(.+)/i);
+    return match ? match[1].trim() : null;
+}
+
+/**
+ * Parses the raw response from the objection classifier LLM call.
+ * Returns the objection type string, or null if the model said no.
+ */
+export function parseClassifierResponse(text: string): string | null {
+    const match = text.match(/^yes:\s*(.+)/i);
+    return match ? match[1].trim() : null;
+}
+
+/**
+ * Calls the LLM as a lightweight classifier to check whether dialogue
+ * gives opposing counsel legal grounds to object.
+ */
+async function runObjectionClassifier(dialogue: string): Promise<string | null> {
+    const response = await llmGenerate({
+        messages: [
+            {
+                role: 'user',
+                content: `Does the following courtroom dialogue give opposing counsel clear legal grounds to object — hearsay, speculation, badgering, or a leading question? Reply only: yes: <type> or no.\n\n"${dialogue}"`,
+            },
+        ],
+        temperature: 0.1,
+        maxTokens: 15,
+    });
+    return parseClassifierResponse(response);
+}
+
+export interface ObjectionRoundInput {
+    dialogue: string;
+    objectingAgentId: AgentId;
+    objectingRole: CourtRole;
+    judgeAgentId: AgentId;
+    generateBudgetedTurn: GenerateBudgetedTurn;
+    store: CourtSessionStore;
+    session: CourtSession;
+    pause: (ms: number) => Promise<void>;
+}
+
+/**
+ * Runs the two-layer objection check for one round.
+ * 1. Check if the attorney organically self-triggered (dialogue starts with OBJECTION:).
+ * 2. If not, run the classifier.
+ * 3. If either fires, and organic did NOT already produce the turn, generate an objection turn.
+ * 4. Judge ALWAYS rules after any objection.
+ */
+export async function handleObjectionRound(input: ObjectionRoundInput): Promise<void> {
+    const organic = detectOrganicObjection(input.dialogue);
+    let objectionType = organic;
+
+    if (!objectionType) {
+        objectionType = await runObjectionClassifier(input.dialogue);
+    }
+
+    if (!objectionType) return;
+
+    // Only generate the attorney objection turn if it was NOT already part of their dialogue
+    if (!organic) {
+        await input.generateBudgetedTurn({
+            store: input.store,
+            session: input.session,
+            speaker: input.objectingAgentId,
+            role: input.objectingRole,
+            userInstruction: `Object to the preceding testimony on grounds of ${objectionType}. Begin your turn with "OBJECTION:" followed by the type and a one-sentence explanation.`,
+        });
+        await input.pause(600);
+    }
+
+    // Judge always rules
+    await input.generateBudgetedTurn({
+        store: input.store,
+        session: input.session,
+        speaker: input.judgeAgentId,
+        role: 'judge',
+        userInstruction:
+            'Rule on the objection that was just raised: sustained or overruled. One sentence, then direct proceedings to continue.',
+    });
+}
+```
+
+**Step 4: Run tests to confirm pass**
+
+```bash
+npm test
+```
+
+Expected: all tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/court/phases/objections.ts src/court/phases/objections.test.ts
+git commit -m "feat: two-layer objection detection — organic self-trigger + classifier safety net"
+```
+
+---
+
+### Task 6: Rewrite `runWitnessExamPhase`
+
+Replace the current judge-opens flow with the full structured bailiff-introduce → direct → cross flow, integrated with the script builder (Task 3), random events (Task 4), and objections (Task 5).
+
+**Files:**
+- Modify: `src/court/phases/session-flow.ts:263-357` (the `runWitnessExamPhase` function)
+
+**Context:** This function currently has judge asking first. The new flow is:
+1. Bailiff introduces each witness by display name + role
+2. Prosecutor direct: 3–7 rounds (script builder) — each round: prosecutor question → witness answer → random event check → objection check or judge interrupt (mutually exclusive)
+3. Defense cross: 2–5 rounds — same structure, opposing roles flipped
+4. Judge recap every N witnesses (unchanged cadence logic)
+
+**Step 1: Add imports at the top of `session-flow.ts`**
+
+After the existing imports, add:
+
+```ts
+import { buildWitnessScripts } from './witness-script.js';
+import { checkRandomEvent, type RandomEvent, type EventSpeaker } from './random-events.js';
+import { handleObjectionRound } from './objections.js';
+import { AGENTS } from '../../agents.js';
+```
+
+**Step 2: Add `shouldJudgeInterrupt` helper before `runWitnessExamPhase`**
+
+```ts
+function shouldJudgeInterrupt(rng: () => number = Math.random, probability = 0.12): boolean {
+    return rng() < probability;
+}
+```
+
+**Step 3: Add `runRandomEvent` helper before `runWitnessExamPhase`**
+
+```ts
+async function runRandomEvent(
+    context: SessionRuntimeContext,
+    event: RandomEvent,
+    witnessId: AgentId,
+    witnessRole: CourtRole,
+    prosecutorId: AgentId,
+    defenseId: AgentId,
+    isDirectExam: boolean,
+): Promise<void> {
+    const speaker: EventSpeaker = event.speaker;
+    let agentId: AgentId;
+    let role: CourtRole;
+
+    if (speaker === 'witness') {
+        agentId = witnessId;
+        role = witnessRole;
+    } else if (speaker === 'bailiff') {
+        agentId = context.session.metadata.roleAssignments.bailiff;
+        role = 'bailiff';
+    } else if (speaker === 'judge') {
+        agentId = context.session.metadata.roleAssignments.judge;
+        role = 'judge';
+    } else {
+        // opposing_counsel: during direct the defense opposes; during cross the prosecution opposes
+        agentId = isDirectExam ? defenseId : prosecutorId;
+        role = isDirectExam ? 'defense' : 'prosecutor';
+    }
+
+    await context.generateBudgetedTurn({
+        store: context.store,
+        session: context.session,
+        speaker: agentId,
+        role,
+        userInstruction: event.userInstruction,
+    });
+}
+```
+
+**Step 4: Replace `runWitnessExamPhase` entirely**
+
+Remove the existing function (lines 263–357) and replace with:
+
+```ts
+export async function runWitnessExamPhase(
+    context: SessionRuntimeContext,
+): Promise<void> {
+    const { judge, prosecutor, defense, witnesses, bailiff } =
+        context.session.metadata.roleAssignments;
+
+    await beginPhase(context, 'witness_exam', PHASE_DURATION_MS.witnessExam);
+    await context.safelySpeak('speakCue', () =>
+        context.tts.speakCue({
+            sessionId: context.session.id,
+            phase: 'witness_exam',
+            text: 'Witness examination begins. The court will hear testimony.',
+        }),
+    );
+
+    const scripts = buildWitnessScripts(witnesses.length);
+    // eslint-disable-next-line no-console
+    console.info(
+        `[witness-exam] session=${context.session.id} scripts=${JSON.stringify(scripts)}`,
+    );
+
+    let witnessIndex = 0;
+
+    for (const witness of witnesses) {
+        const script = scripts[witnessIndex]!;
+        const witnessRole = `witness_${Math.min(witnessIndex + 1, MAX_WITNESS_ROLE_INDEX)}` as CourtRole;
+        const witnessConfig = AGENTS[witness];
+
+        // 1. Bailiff introduces witness
+        await context.pause(PAUSE_MS.witnessBetweenTurns);
+        await context.generateBudgetedTurn({
+            store: context.store,
+            session: context.session,
+            speaker: bailiff,
+            role: 'bailiff',
+            userInstruction: `Call ${witnessConfig.displayName} (${witnessConfig.role}) to the stand. Announce their name and role formally and briefly.`,
+        });
+        await context.pause(PAUSE_MS.witnessBetweenTurns);
+
+        // 2. Direct examination
+        for (let q = 0; q < script.directRounds; q++) {
+            const prosecutorTurn = await context.generateBudgetedTurn({
+                store: context.store,
+                session: context.session,
+                speaker: prosecutor,
+                role: 'prosecutor',
+                userInstruction: `Ask ${witnessConfig.displayName} a focused question about the core accusation. Direct examination question ${q + 1} of ${script.directRounds}. If you have grounds to object to anything said previously, begin with "OBJECTION:" followed by the type.`,
+            });
+            await context.pause(PAUSE_MS.witnessBetweenTurns);
+
+            const witnessTurn = await context.generateBudgetedTurn({
+                store: context.store,
+                session: context.session,
+                speaker: witness,
+                role: witnessRole,
+                userInstruction:
+                    'Answer the question in 1–3 sentences with one concrete detail. Be truthful — or convincingly not.',
+                maxTokens: Math.min(
+                    MAX_WITNESS_TURN_TOKENS,
+                    context.witnessCapConfig
+                        ? (effectiveTokenLimit(context.witnessCapConfig).limit ?? MAX_WITNESS_TURN_TOKENS)
+                        : MAX_WITNESS_TURN_TOKENS,
+                ),
+                capConfig: context.witnessCapConfig,
+            });
+            await context.pause(PAUSE_MS.witnessBetweenTurns);
+
+            // Random event check
+            const event = checkRandomEvent();
+            if (event) {
+                await runRandomEvent(context, event, witness, witnessRole, prosecutor, defense, true);
+                await context.pause(PAUSE_MS.witnessBetweenTurns);
+            }
+
+            // Judge interrupt or objection check (mutually exclusive)
+            if (shouldJudgeInterrupt()) {
+                await context.generateBudgetedTurn({
+                    store: context.store,
+                    session: context.session,
+                    speaker: judge,
+                    role: 'judge',
+                    userInstruction:
+                        'Briefly clarify a procedural point or give a short instruction to the jury. One or two sentences.',
+                });
+                await context.pause(PAUSE_MS.witnessBetweenTurns);
+            } else {
+                await handleObjectionRound({
+                    dialogue: witnessTurn.dialogue,
+                    objectingAgentId: defense,
+                    objectingRole: 'defense',
+                    judgeAgentId: judge,
+                    generateBudgetedTurn: context.generateBudgetedTurn,
+                    store: context.store,
+                    session: context.session,
+                    pause: context.pause,
+                });
+            }
+        }
+
+        // 3. Cross-examination
+        for (let q = 0; q < script.crossRounds; q++) {
+            const defenseTurn = await context.generateBudgetedTurn({
+                store: context.store,
+                session: context.session,
+                speaker: defense,
+                role: 'defense',
+                userInstruction: `Cross-examine ${witnessConfig.displayName} with one pointed challenge. Cross question ${q + 1} of ${script.crossRounds}. If you have grounds to object to anything said previously, begin with "OBJECTION:" followed by the type.`,
+            });
+            await context.pause(PAUSE_MS.witnessBetweenTurns);
+
+            const witnessCrossTurn = await context.generateBudgetedTurn({
+                store: context.store,
+                session: context.session,
+                speaker: witness,
+                role: witnessRole,
+                userInstruction:
+                    'Respond to the cross-examination in 1–3 sentences. You may be evasive, emotional, or suspiciously specific.',
+                maxTokens: Math.min(
+                    MAX_WITNESS_TURN_TOKENS,
+                    context.witnessCapConfig
+                        ? (effectiveTokenLimit(context.witnessCapConfig).limit ?? MAX_WITNESS_TURN_TOKENS)
+                        : MAX_WITNESS_TURN_TOKENS,
+                ),
+                capConfig: context.witnessCapConfig,
+            });
+            await context.pause(PAUSE_MS.witnessBetweenTurns);
+
+            // Random event check
+            const crossEvent = checkRandomEvent();
+            if (crossEvent) {
+                await runRandomEvent(context, crossEvent, witness, witnessRole, prosecutor, defense, false);
+                await context.pause(PAUSE_MS.witnessBetweenTurns);
+            }
+
+            // Judge interrupt or objection check (mutually exclusive)
+            if (shouldJudgeInterrupt()) {
+                await context.generateBudgetedTurn({
+                    store: context.store,
+                    session: context.session,
+                    speaker: judge,
+                    role: 'judge',
+                    userInstruction:
+                        'Briefly clarify a procedural point or give a short instruction to the jury. One or two sentences.',
+                });
+                await context.pause(PAUSE_MS.witnessBetweenTurns);
+            } else {
+                await handleObjectionRound({
+                    dialogue: witnessCrossTurn.dialogue,
+                    objectingAgentId: prosecutor,
+                    objectingRole: 'prosecutor',
+                    judgeAgentId: judge,
+                    generateBudgetedTurn: context.generateBudgetedTurn,
+                    store: context.store,
+                    session: context.session,
+                    pause: context.pause,
+                });
+            }
+        }
+
+        // Judge recap at cadence
+        witnessIndex += 1;
+        if (witnessIndex % context.recapCadence === 0) {
+            await context.pause(PAUSE_MS.recapLeadIn);
+            const recapTurn = await context.generateBudgetedTurn({
+                store: context.store,
+                session: context.session,
+                speaker: judge,
+                role: 'judge',
+                userInstruction:
+                    'Give a two-sentence recap of what matters so far and keep the jury oriented.',
+                dialoguePrefix: 'Recap:',
+            });
+
+            await context.store.recordRecap({
+                sessionId: context.session.id,
+                turnId: recapTurn.id,
+                phase: context.session.phase,
+                cycleNumber: witnessIndex,
+            });
+
+            await context.safelySpeak('speakRecap', () =>
+                context.tts.speakRecap({
+                    sessionId: context.session.id,
+                    phase: 'witness_exam',
+                    text: recapTurn.dialogue,
+                }),
+            );
+        }
+
+        await context.pause(PAUSE_MS.witnessBetweenCycles);
+    }
+}
+```
+
+**Step 5: Run tests**
+
+```bash
+npm test
+```
+
+Expected: all tests pass. If TypeScript errors appear, check import paths — they must use `.js` extensions (e.g., `'./witness-script.js'` not `'./witness-script'`).
+
+**Step 6: Commit**
+
+```bash
+git add src/court/phases/session-flow.ts
+git commit -m "feat: restructure witness exam — bailiff intro, direct/cross, script builder, random events, objections"
+```
+
+---
+
+## Test Command Reference
+
+```bash
+# Run all tests
+npm test
+
+# Run a single test file
+node --import tsx --test src/court/phases/witness-script.test.ts
+
+# TypeScript type check only
+npm run lint
+```
+
+## Notes for Implementer
+
+- All `.ts` imports must use `.js` extensions (ESM requirement of this project)
+- The test runner is Node's built-in `node:test` — no Jest, no Vitest
+- `LLM_MOCK=true` is set automatically when `--test` is in `process.argv`, so `llmGenerate` calls in objection tests return mock dialogue (not real LLM calls)
+- The `effectiveTokenLimit` import is already in `session-flow.ts` — do not remove it
+- `AGENTS` is imported from `'../../agents.js'` in orchestrator — same path pattern for session-flow

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
                 "autoprefixer": "^10.4.20",
                 "postcss": "^8.4.49",
                 "tailwindcss": "^3.4.17",
-                "tsx": "^4.20.5",
+                "tsx": "^4.21.0",
                 "typescript": "^5.9.3",
                 "vite": "^6.0.7"
             }

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
         "express-rate-limit": "^8.2.1",
         "howler": "^2.2.4",
         "pixi.js": "^8.0.0",
-        "prom-client": "^15.1.3",
         "postgres": "^3.4.5",
+        "prom-client": "^15.1.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "tmi.js": "^1.8.5"
@@ -41,7 +41,7 @@
         "autoprefixer": "^10.4.20",
         "postcss": "^8.4.49",
         "tailwindcss": "^3.4.17",
-        "tsx": "^4.20.5",
+        "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vite": "^6.0.7"
     }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "lint": "tsc --noEmit",
         "build": "tsc -p tsconfig.json && vite build",
         "build:dashboard": "vite build",
-        "test": "node --import tsx --test src/*.test.ts src/**/*.test.ts",
+        "test": "node --import tsx --test 'src/**/*.test.ts'",
         "test:ops": "node --import tsx --test src/ops/ops-config.test.ts",
         "smoke:staging": "bash ./scripts/staging-smoke.sh",
         "start": "node dist/server.js",

--- a/public/app.js
+++ b/public/app.js
@@ -76,7 +76,7 @@ const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 10_000;
 const CATCHUP_MAX_CHARS = 220;
 const TIMER_TICK_MS = 250;
-const TYPEWRITER_CHARS_PER_SECOND = 48;
+const TYPEWRITER_CHARS_PER_SECOND = 200 / 60; // 200 CPM — matches server-side display pacing
 
 const fixtureReplayState = {
     active: false,

--- a/src/court/phases/objections.test.ts
+++ b/src/court/phases/objections.test.ts
@@ -1,0 +1,45 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { detectOrganicObjection, parseClassifierResponse } from './objections.js';
+
+describe('detectOrganicObjection', () => {
+    it('detects OBJECTION: at start of dialogue', () => {
+        const result = detectOrganicObjection('OBJECTION: hearsay. That is inadmissible.');
+        assert.equal(result, 'hearsay. That is inadmissible.');
+    });
+
+    it('is case-insensitive', () => {
+        const result = detectOrganicObjection('Objection: leading question.');
+        assert.equal(result, 'leading question.');
+    });
+
+    it('returns null when dialogue does not start with OBJECTION:', () => {
+        assert.equal(detectOrganicObjection('I strongly disagree with that characterisation.'), null);
+    });
+
+    it('returns null for empty string', () => {
+        assert.equal(detectOrganicObjection(''), null);
+    });
+
+    it('does not match OBJECTION mid-sentence', () => {
+        assert.equal(detectOrganicObjection('Counsel raises an OBJECTION: hearsay.'), null);
+    });
+});
+
+describe('parseClassifierResponse', () => {
+    it('returns objection type for yes: response', () => {
+        assert.equal(parseClassifierResponse('yes: hearsay'), 'hearsay');
+    });
+
+    it('is case-insensitive', () => {
+        assert.equal(parseClassifierResponse('Yes: Speculation'), 'Speculation');
+    });
+
+    it('returns null for no', () => {
+        assert.equal(parseClassifierResponse('no'), null);
+    });
+
+    it('returns null for empty string', () => {
+        assert.equal(parseClassifierResponse(''), null);
+    });
+});

--- a/src/court/phases/objections.ts
+++ b/src/court/phases/objections.ts
@@ -48,6 +48,7 @@ export interface ObjectionRoundInput {
     store: CourtSessionStore;
     session: CourtSession;
     pause: (ms: number) => Promise<void>;
+    pauseMs: number;
 }
 
 /**
@@ -76,7 +77,7 @@ export async function handleObjectionRound(input: ObjectionRoundInput): Promise<
             role: input.objectingRole,
             userInstruction: `Object to the preceding testimony on grounds of ${objectionType}. Begin your turn with "OBJECTION:" followed by the type and a one-sentence explanation.`,
         });
-        await input.pause(600);
+        await input.pause(input.pauseMs);
     }
 
     // Judge always rules

--- a/src/court/phases/objections.ts
+++ b/src/court/phases/objections.ts
@@ -1,0 +1,91 @@
+import type { AgentId, CourtRole, CourtSession } from '../../types.js';
+import type { CourtSessionStore } from '../../store/session-store.js';
+import { llmGenerate } from '../../llm/client.js';
+import type { GenerateBudgetedTurn } from './session-flow.js';
+
+/**
+ * Checks if the attorney self-triggered an objection by beginning dialogue with "OBJECTION:".
+ * Returns the text after "OBJECTION:" (the objection type + explanation), or null.
+ */
+export function detectOrganicObjection(dialogue: string): string | null {
+    const match = dialogue.match(/^OBJECTION:\s*(.+)/i);
+    return match ? match[1].trim() : null;
+}
+
+/**
+ * Parses the raw response from the objection classifier LLM call.
+ * Returns the objection type string, or null if the model said no.
+ */
+export function parseClassifierResponse(text: string): string | null {
+    const match = text.match(/^yes:\s*(.+)/i);
+    return match ? match[1].trim() : null;
+}
+
+/**
+ * Calls the LLM as a lightweight classifier to check whether dialogue
+ * gives opposing counsel legal grounds to object.
+ */
+async function runObjectionClassifier(dialogue: string): Promise<string | null> {
+    const response = await llmGenerate({
+        messages: [
+            {
+                role: 'user',
+                content: `Does the following courtroom dialogue give opposing counsel clear legal grounds to object — hearsay, speculation, badgering, or a leading question? Reply only: yes: <type> or no.\n\n"${dialogue}"`,
+            },
+        ],
+        temperature: 0.1,
+        maxTokens: 15,
+    });
+    return parseClassifierResponse(response);
+}
+
+export interface ObjectionRoundInput {
+    dialogue: string;
+    objectingAgentId: AgentId;
+    objectingRole: CourtRole;
+    judgeAgentId: AgentId;
+    generateBudgetedTurn: GenerateBudgetedTurn;
+    store: CourtSessionStore;
+    session: CourtSession;
+    pause: (ms: number) => Promise<void>;
+}
+
+/**
+ * Two-layer objection check for one round.
+ * 1. Check if the attorney organically self-triggered (dialogue starts with OBJECTION:).
+ * 2. If not, run the LLM classifier as a safety net.
+ * 3. If either fires and organic did NOT already produce the turn, generate an objection turn.
+ * 4. Judge ALWAYS rules after any objection.
+ */
+export async function handleObjectionRound(input: ObjectionRoundInput): Promise<void> {
+    const organic = detectOrganicObjection(input.dialogue);
+    let objectionType = organic;
+
+    if (!objectionType) {
+        objectionType = await runObjectionClassifier(input.dialogue);
+    }
+
+    if (!objectionType) return;
+
+    // Only generate the attorney objection turn if it was NOT already part of their dialogue
+    if (!organic) {
+        await input.generateBudgetedTurn({
+            store: input.store,
+            session: input.session,
+            speaker: input.objectingAgentId,
+            role: input.objectingRole,
+            userInstruction: `Object to the preceding testimony on grounds of ${objectionType}. Begin your turn with "OBJECTION:" followed by the type and a one-sentence explanation.`,
+        });
+        await input.pause(600);
+    }
+
+    // Judge always rules
+    await input.generateBudgetedTurn({
+        store: input.store,
+        session: input.session,
+        speaker: input.judgeAgentId,
+        role: 'judge',
+        userInstruction:
+            'Rule on the objection that was just raised: sustained or overruled. One sentence, then direct proceedings to continue.',
+    });
+}

--- a/src/court/phases/random-events.test.ts
+++ b/src/court/phases/random-events.test.ts
@@ -16,9 +16,11 @@ describe('checkRandomEvent', () => {
     });
 
     it('returns at most one event per call', () => {
-        // Even when rng fires everything, only one event is returned
+        // Even when rng fires everything, only one event is returned (never an array)
         const result = checkRandomEvent(() => 0.0);
-        assert.ok(result === null || typeof result.id === 'string');
+        assert.ok(
+            result === null || (!Array.isArray(result) && typeof result.id === 'string'),
+        );
     });
 
     it('all RANDOM_EVENTS have required fields', () => {

--- a/src/court/phases/random-events.test.ts
+++ b/src/court/phases/random-events.test.ts
@@ -1,0 +1,33 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { checkRandomEvent, RANDOM_EVENTS } from './random-events.js';
+
+describe('checkRandomEvent', () => {
+    it('returns null when rng always returns 1.0 (above all probabilities)', () => {
+        const result = checkRandomEvent(() => 1.0);
+        assert.equal(result, null);
+    });
+
+    it('returns an event when rng always returns 0.0 (below all probabilities)', () => {
+        const result = checkRandomEvent(() => 0.0);
+        assert.ok(result !== null);
+        assert.ok(typeof result.id === 'string');
+        assert.ok(typeof result.userInstruction === 'string');
+    });
+
+    it('returns at most one event per call', () => {
+        // Even when rng fires everything, only one event is returned
+        const result = checkRandomEvent(() => 0.0);
+        assert.ok(result === null || typeof result.id === 'string');
+    });
+
+    it('all RANDOM_EVENTS have required fields', () => {
+        for (const event of RANDOM_EVENTS) {
+            assert.ok(typeof event.id === 'string', `event.id missing: ${JSON.stringify(event)}`);
+            assert.ok(typeof event.probability === 'number');
+            assert.ok(event.probability > 0 && event.probability < 1);
+            assert.ok(typeof event.speaker === 'string');
+            assert.ok(typeof event.userInstruction === 'string');
+        }
+    });
+});

--- a/src/court/phases/random-events.ts
+++ b/src/court/phases/random-events.ts
@@ -1,0 +1,62 @@
+export type EventSpeaker = 'witness' | 'bailiff' | 'judge' | 'opposing_counsel';
+
+export interface RandomEvent {
+    id: string;
+    probability: number;
+    speaker: EventSpeaker;
+    userInstruction: string;
+}
+
+export const RANDOM_EVENTS: RandomEvent[] = [
+    {
+        id: 'witness_outburst',
+        probability: 0.12,
+        speaker: 'witness',
+        userInstruction:
+            'Have an emotional or bizarre outburst relevant to the case. Stay in character but go off-script in an unexpected way that reveals something about your relationship to the events.',
+    },
+    {
+        id: 'dramatic_revelation',
+        probability: 0.08,
+        speaker: 'witness',
+        userInstruction:
+            'Blurt out an unexpected detail that reframes the entire case. Make it dramatic, specific to the case topic, and something neither side was expecting.',
+    },
+    {
+        id: 'bailiff_interruption',
+        probability: 0.08,
+        speaker: 'bailiff',
+        userInstruction:
+            'Briefly interrupt proceedings to address a minor courtroom disturbance. Keep it short, procedural, and mildly absurd.',
+    },
+    {
+        id: 'gallery_disruption',
+        probability: 0.06,
+        speaker: 'judge',
+        userInstruction:
+            'Restore order after the public gallery disrupts proceedings. Be authoritative and slightly exasperated. One or two sentences.',
+    },
+    {
+        id: 'evidence_challenged',
+        probability: 0.10,
+        speaker: 'opposing_counsel',
+        userInstruction:
+            'Challenge the evidentiary basis of the preceding question or answer. Be specific about what you are challenging and why it is inadmissible or misleading.',
+    },
+];
+
+/**
+ * Checks whether a random event fires this round.
+ * Accepts an injectable `rng` for deterministic testing.
+ * Returns at most one event; returns null if none fire.
+ */
+export function checkRandomEvent(rng: () => number = Math.random): RandomEvent | null {
+    // Shuffle catalogue so higher-probability events don't always win on ties
+    const shuffled = [...RANDOM_EVENTS].sort(() => rng() - 0.5);
+    for (const event of shuffled) {
+        if (rng() < event.probability) {
+            return event;
+        }
+    }
+    return null;
+}

--- a/src/court/phases/random-events.ts
+++ b/src/court/phases/random-events.ts
@@ -51,8 +51,12 @@ export const RANDOM_EVENTS: RandomEvent[] = [
  * Returns at most one event; returns null if none fire.
  */
 export function checkRandomEvent(rng: () => number = Math.random): RandomEvent | null {
-    // Shuffle catalogue so higher-probability events don't always win on ties
-    const shuffled = [...RANDOM_EVENTS].sort(() => rng() - 0.5);
+    // Fisher-Yates shuffle so higher-probability events don't always win on ties
+    const shuffled = [...RANDOM_EVENTS];
+    for (let i = shuffled.length - 1; i > 0; i--) {
+        const j = Math.min(i, Math.floor(rng() * (i + 1)));
+        [shuffled[i], shuffled[j]] = [shuffled[j]!, shuffled[i]!];
+    }
     for (const event of shuffled) {
         if (rng() < event.probability) {
             return event;

--- a/src/court/phases/session-flow.ts
+++ b/src/court/phases/session-flow.ts
@@ -23,12 +23,12 @@ const PHASE_DURATION_MS = {
 } as const;
 
 const PAUSE_MS = {
-    casePromptAfterCue: 1_200,
-    openingBetweenSides: 900,
-    witnessBetweenTurns: 600,
-    witnessBetweenCycles: 800,
-    recapLeadIn: 600,
-    closingBetweenSides: 800,
+    casePromptAfterCue: 2_000,
+    openingBetweenSides: 2_000,
+    witnessBetweenTurns: 2_500,
+    witnessBetweenCycles: 3_000,
+    recapLeadIn: 1_500,
+    closingBetweenSides: 2_000,
 } as const;
 
 const MAX_WITNESS_TURN_TOKENS = 260;

--- a/src/court/phases/session-flow.ts
+++ b/src/court/phases/session-flow.ts
@@ -347,7 +347,7 @@ export async function runWitnessExamPhase(
 
         // 2. Direct examination
         for (let q = 0; q < script.directRounds; q++) {
-            const prosecutorTurn = await context.generateBudgetedTurn({
+            await context.generateBudgetedTurn({
                 store: context.store,
                 session: context.session,
                 speaker: prosecutor,

--- a/src/court/phases/session-flow.ts
+++ b/src/court/phases/session-flow.ts
@@ -29,6 +29,7 @@ const PHASE_DURATION_MS = {
 const PAUSE_MS = {
     casePromptAfterCue: 2_000,
     witnessBetweenCycles: 3_000,
+    witnessBetweenTurns: 2_500,
     recapLeadIn: 1_500,
 } as const;
 
@@ -358,7 +359,7 @@ export async function runWitnessExamPhase(
                 session: context.session,
                 speaker: prosecutor,
                 role: 'prosecutor',
-                userInstruction: `Ask ${witnessConfig.displayName} a focused question about the core accusation. Direct examination question ${q + 1} of ${script.directRounds}. If you have grounds to object to anything said previously, begin with "OBJECTION:" followed by the type.`,
+                userInstruction: `Ask ${witnessConfig.displayName} a focused question about the core accusation. Direct examination question ${q + 1} of ${script.directRounds}.`,
             });
             await context.pause(displayPauseMs(prosecutorTurn.dialogue));
 
@@ -406,7 +407,7 @@ export async function runWitnessExamPhase(
                 await context.pause(displayPauseMs(judgeInterruptTurn.dialogue));
             } else {
                 await handleObjectionRound({
-                    dialogue: witnessTurn.dialogue,
+                    dialogue: prosecutorTurn.dialogue,
                     objectingAgentId: defense,
                     objectingRole: 'defense',
                     judgeAgentId: judge,
@@ -414,6 +415,7 @@ export async function runWitnessExamPhase(
                     store: context.store,
                     session: context.session,
                     pause: context.pause,
+                    pauseMs: PAUSE_MS.witnessBetweenTurns,
                 });
             }
         }
@@ -425,7 +427,7 @@ export async function runWitnessExamPhase(
                 session: context.session,
                 speaker: defense,
                 role: 'defense',
-                userInstruction: `Cross-examine ${witnessConfig.displayName} with one pointed challenge. Cross question ${q + 1} of ${script.crossRounds}. If you have grounds to object to anything said previously, begin with "OBJECTION:" followed by the type.`,
+                userInstruction: `Cross-examine ${witnessConfig.displayName} with one pointed challenge. Cross question ${q + 1} of ${script.crossRounds}.`,
             });
             await context.pause(displayPauseMs(defenseTurn.dialogue));
 
@@ -473,7 +475,7 @@ export async function runWitnessExamPhase(
                 await context.pause(displayPauseMs(judgeInterruptTurn.dialogue));
             } else {
                 await handleObjectionRound({
-                    dialogue: witnessCrossTurn.dialogue,
+                    dialogue: defenseTurn.dialogue,
                     objectingAgentId: prosecutor,
                     objectingRole: 'prosecutor',
                     judgeAgentId: judge,
@@ -481,6 +483,7 @@ export async function runWitnessExamPhase(
                     store: context.store,
                     session: context.session,
                     pause: context.pause,
+                    pauseMs: PAUSE_MS.witnessBetweenTurns,
                 });
             }
         }

--- a/src/court/phases/witness-script.test.ts
+++ b/src/court/phases/witness-script.test.ts
@@ -1,0 +1,43 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildWitnessScripts } from './witness-script.js';
+
+describe('buildWitnessScripts', () => {
+    it('returns one script per witness', () => {
+        const scripts = buildWitnessScripts(3);
+        assert.equal(scripts.length, 3);
+    });
+
+    it('direct rounds are in range 3–7', () => {
+        for (let i = 0; i < 50; i++) {
+            const [script] = buildWitnessScripts(1);
+            assert.ok(
+                script!.directRounds >= 3 && script!.directRounds <= 7,
+                `directRounds out of range: ${script!.directRounds}`,
+            );
+        }
+    });
+
+    it('cross rounds are in range 2–5', () => {
+        for (let i = 0; i < 50; i++) {
+            const [script] = buildWitnessScripts(1);
+            assert.ok(
+                script!.crossRounds >= 2 && script!.crossRounds <= 5,
+                `crossRounds out of range: ${script!.crossRounds}`,
+            );
+        }
+    });
+
+    it('witnesses get independent rolls', () => {
+        const scripts = buildWitnessScripts(20);
+        const directCounts = new Set(scripts.map(s => s.directRounds));
+        assert.ok(
+            directCounts.size > 1,
+            'All 20 witnesses got identical directRounds — extremely unlikely if random',
+        );
+    });
+
+    it('returns empty array for 0 witnesses', () => {
+        assert.deepEqual(buildWitnessScripts(0), []);
+    });
+});

--- a/src/court/phases/witness-script.ts
+++ b/src/court/phases/witness-script.ts
@@ -1,0 +1,11 @@
+export interface WitnessScript {
+    directRounds: number; // 3–7
+    crossRounds: number;  // 2–5
+}
+
+export function buildWitnessScripts(witnessCount: number): WitnessScript[] {
+    return Array.from({ length: witnessCount }, () => ({
+        directRounds: Math.floor(Math.random() * 5) + 3,
+        crossRounds: Math.floor(Math.random() * 4) + 2,
+    }));
+}

--- a/src/court/phases/witness-script.ts
+++ b/src/court/phases/witness-script.ts
@@ -3,9 +3,12 @@ export interface WitnessScript {
     crossRounds: number;  // 2–5
 }
 
-export function buildWitnessScripts(witnessCount: number): WitnessScript[] {
+export function buildWitnessScripts(
+    witnessCount: number,
+    rng: () => number = Math.random,
+): WitnessScript[] {
     return Array.from({ length: witnessCount }, () => ({
-        directRounds: Math.floor(Math.random() * 5) + 3,
-        crossRounds: Math.floor(Math.random() * 4) + 2,
+        directRounds: Math.floor(rng() * 5) + 3,
+        crossRounds: Math.floor(rng() * 4) + 2,
     }));
 }

--- a/src/llm/client.test.ts
+++ b/src/llm/client.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { llmGenerate } from './client.js';
 
-type EnvKey = 'OPENROUTER_API_KEY' | 'LLM_MOCK' | 'LLM_MODEL';
+type EnvKey = 'OPENROUTER_API_KEY' | 'LLM_MOCK' | 'LLM_MODELS';
 
 function withTemporaryEnv(
     updates: Partial<Record<EnvKey, string>>,
@@ -58,7 +58,7 @@ test('llmGenerate falls back when provider returns empty message content', async
         {
             OPENROUTER_API_KEY: 'test-key',
             LLM_MOCK: 'false',
-            LLM_MODEL: 'stepfun/step-3.5-flash:free',
+            LLM_MODELS: 'stepfun/step-3.5-flash:free',
         },
         async () => {
             const output = await llmGenerate({
@@ -75,12 +75,7 @@ test('llmGenerate falls back when provider returns empty message content', async
                 maxTokens: 180,
             });
 
-            assert.notEqual(
-                output,
-                '',
-                'Expected non-empty fallback text when model content is empty',
-            );
-            assert.match(output, /Ladies and gentlemen/i);
+            assert.ok(output.length > 0, 'Expected non-empty fallback text when model content is empty');
         },
     ).finally(() => {
         globalThis.fetch = originalFetch;
@@ -119,7 +114,7 @@ test('llmGenerate returns sanitized provider content when non-empty', async () =
         {
             OPENROUTER_API_KEY: 'test-key',
             LLM_MOCK: 'false',
-            LLM_MODEL: 'stepfun/step-3.5-flash:free',
+            LLM_MODELS: 'stepfun/step-3.5-flash:free',
         },
         async () => {
             const output = await llmGenerate({

--- a/src/llm/client.ts
+++ b/src/llm/client.ts
@@ -51,20 +51,73 @@ export function sanitizeDialogue(text: string): string {
         .trim();
 }
 
+const MOCK_LINES: Array<{ pattern: RegExp; lines: string[] }> = [
+    {
+        pattern: /opening|statement/i,
+        lines: [
+            'The facts in this case are stranger than fiction, and the fiction is not great either. We intend to prove every last strange bit of it.',
+            'The evidence will speak for itself — loudly, incoherently, and with unusual conviction.',
+            'What you are about to hear is either a crime or a misunderstanding of historic proportions. Possibly both.',
+            'The prosecution will demonstrate, beyond reasonable doubt, that something happened. The exact nature of that something will become abundantly clear.',
+            'We ask only that you keep an open mind — and perhaps a strong stomach.',
+            'The defense maintains our client is innocent, and also maintains several other positions that will be revealed at the worst possible moment.',
+        ],
+    },
+    {
+        pattern: /witness|testimony|cross/i,
+        lines: [
+            'I can state with certainty that I observed something. The details are fuzzy, but the certainty is very high.',
+            'At the time I thought nothing of it. In retrospect I should have thought quite a lot of it.',
+            'I was present. I was observing. What I observed is what you might call difficult to categorize.',
+            'Everything I am about to say is accurate to the best of my recollection, which is doing its best.',
+            'There was an incident. I was adjacent to it. My proximity was noted by several parties, including myself.',
+            'I remember it clearly: there was a moment, and I was in it. The moment was notable. That is my testimony.',
+        ],
+    },
+    {
+        pattern: /closing/i,
+        lines: [
+            'The evidence has spoken. It has spoken at length, somewhat repetitively, and with great emotional commitment.',
+            'We ask you to weigh the facts — not the feelings, not the drama, not the seventeen things that went unexpectedly sideways.',
+            'One truth remains: something happened, someone did it, and this court must decide what happens next.',
+            'The defense rests — on the bedrock of reasonable doubt and a sincere belief that this has all gone far enough.',
+            'Justice demands a verdict. Logic demands clarity. The circumstances demand a stiff drink and a long lie-down.',
+            'I leave you with this: whatever you decide, decide it with the full weight of your conscience and at least two of your five senses.',
+        ],
+    },
+    {
+        pattern: /ruling|verdict/i,
+        lines: [
+            'On the matter before this court, I have considered the evidence, the arguments, and my own rising blood pressure. The verdict stands.',
+            'This court finds the evidence compelling in ways that are difficult to articulate but impossible to ignore.',
+            'I have heard enough. The court has heard enough. The court reporter has definitely heard enough.',
+            'The ruling of this court is final. The chaos leading to it was anything but. Proceedings are concluded.',
+            'After careful deliberation — I wrote things down — this court delivers its judgment.',
+            'This court has seen many things. Most of them were other cases. Nevertheless, a verdict is reached.',
+        ],
+    },
+];
+
+const MOCK_LINES_DEFAULT = [
+    'Noted. The court acknowledges the point and invites us all to move forward with cautious optimism.',
+    'Order. We proceed. Whatever just happened, we proceed from it.',
+    'The record reflects the current state of affairs. The current state of affairs is noted.',
+    'This court will take that under advisement. We advise ourselves to continue.',
+    'The relevant determination having been made, proceedings continue.',
+    'So noted. The court is, as always, moving forward.',
+];
+
+function pickRandom<T>(arr: [T, ...T[]]): T {
+    return arr[Math.floor(Math.random() * arr.length)];
+}
+
 function mockReply(prompt: string): string {
-    if (/opening|statement/i.test(prompt)) {
-        return 'Ladies and gentlemen of the jury, the facts are weird, the timeline is worse, and someone absolutely touched the thermostat without consent.';
+    for (const { pattern, lines } of MOCK_LINES) {
+        if (pattern.test(prompt)) {
+            return pickRandom(lines as [string, ...string[]]);
+        }
     }
-    if (/witness|testimony|cross/i.test(prompt)) {
-        return 'I saw the defendant near the snack cabinet at 2:03 AM, holding a spoon and what looked like emotional intent.';
-    }
-    if (/closing/i.test(prompt)) {
-        return 'At the end of the day, this is either a crime or a spectacular misunderstanding involving glitter and plausible deniability.';
-    }
-    if (/ruling|verdict/i.test(prompt)) {
-        return 'On the charge of chaos in the first degree, this court finds the defendant dramatically guilty—with style points.';
-    }
-    return 'Order in the court. I acknowledge the point and move us to the next absurdly important matter.';
+    return pickRandom(MOCK_LINES_DEFAULT as [string, ...string[]]);
 }
 
 async function tryModelGenerate(


### PR DESCRIPTION
## Summary

- **Witness exam restructured**: bailiff now introduces each witness by name/role; prosecutor directs (3–7 rounds); defense crosses (2–5 rounds); judge never opens questioning — only interrupts for clarifications (~12% chance per round) or rules on objections
- **Script builder**: round counts drawn randomly per witness at phase start and logged to console
- **Random events**: 5 probability-weighted courtroom disruptions (witness outburst, dramatic revelation, bailiff interruption, gallery disruption, evidence challenged) checked each round with injectable RNG for deterministic testing
- **Layered objections**: organic self-trigger detection (attorney dialogue starts with `OBJECTION:`) + LLM classifier safety net; judge always rules after any objection fires; no objection check follows a judge turn
- **Pacing**: all inter-turn delays increased for Twitch viewing comfort (e.g. `witnessBetweenTurns` 600ms → 2,500ms)
- **Mock dialogue variety**: `mockReply()` now picks randomly from 6 generic, case-agnostic lines per category instead of returning the same fixed string

## Test Plan

- [x] `npm test` — 189 pass, 0 fail, 2 skipped (postgres-only)
- [x] `npm run lint` — zero TypeScript errors
- [ ] Live run with LLM API to verify witness flow structure, objection triggers, and pacing feel

🤖 Generated with [Claude Code](https://claude.com/claude-code)