### PR TITLE
feat(twitch): wire tmi.js IRC bot and connect to court API

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1023,7 +1023,9 @@ export async function createServerApp(
     });
 
     twitchBot.start().catch(err => {
-        console.warn('[Twitch Bot] Failed to start:', err);
+        logger.warn(
+            `[Twitch Bot] Failed to start: ${err instanceof Error ? err.message : String(err)}`,
+        );
     });
 
     registerStaticAndSpaRoutes(app, {

--- a/src/twitch/bot.test.ts
+++ b/src/twitch/bot.test.ts
@@ -1,0 +1,42 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { TwitchBot } from './bot.js';
+
+describe('TwitchBot.parseCommand', () => {
+    // Instantiate without credentials → noop mode, but parseCommand still works
+    const bot = new TwitchBot();
+
+    it('parses !press command', () => {
+        const result = bot.parseCommand('!press 2', 'viewer1');
+        assert.ok(result, 'should return a command');
+        assert.equal(result.action, 'press');
+        assert.equal(result.params.statementNumber, 2);
+        assert.equal(result.username, 'viewer1');
+    });
+
+    it('parses !present command', () => {
+        const result = bot.parseCommand('!present banana', 'viewer2');
+        assert.ok(result, 'should return a command');
+        assert.equal(result.action, 'present');
+        assert.equal(result.params.evidenceId, 'banana');
+    });
+
+    it('returns null for unknown command', () => {
+        const result = bot.parseCommand('!unknown', 'viewer3');
+        assert.equal(result, null);
+    });
+
+    it('returns null for non-command message', () => {
+        const result = bot.parseCommand('hello world', 'viewer4');
+        assert.equal(result, null);
+    });
+
+    it('rate-limits duplicate commands from same user', () => {
+        // First command allowed
+        const first = bot.parseCommand('!press 1', 'spammer');
+        assert.ok(first);
+        // Same command within duplicate window → blocked
+        const second = bot.parseCommand('!press 1', 'spammer');
+        assert.equal(second, null, 'duplicate should be rate-limited');
+    });
+});

--- a/src/twitch/bot.test.ts
+++ b/src/twitch/bot.test.ts
@@ -45,7 +45,18 @@ describe('TwitchBot.forwardCommand routing', () => {
     const requests: Array<{ url: string; body: unknown }> = [];
     const originalFetch = globalThis.fetch;
 
+    // Save original env var values so we can restore them (not just delete them)
+    let origChannel: string | undefined;
+    let origBotToken: string | undefined;
+    let origClientId: string | undefined;
+    let origClientSecret: string | undefined;
+
     before(() => {
+        origChannel = process.env.TWITCH_CHANNEL;
+        origBotToken = process.env.TWITCH_BOT_TOKEN;
+        origClientId = process.env.TWITCH_CLIENT_ID;
+        origClientSecret = process.env.TWITCH_CLIENT_SECRET;
+
         // Set env vars so credential check passes when constructing with config
         process.env.TWITCH_CHANNEL = 'test';
         process.env.TWITCH_BOT_TOKEN = 'oauth:test';
@@ -63,10 +74,19 @@ describe('TwitchBot.forwardCommand routing', () => {
     });
 
     after(() => {
-        delete process.env.TWITCH_CHANNEL;
-        delete process.env.TWITCH_BOT_TOKEN;
-        delete process.env.TWITCH_CLIENT_ID;
-        delete process.env.TWITCH_CLIENT_SECRET;
+        // Restore original env var values
+        if (origChannel === undefined) delete process.env.TWITCH_CHANNEL;
+        else process.env.TWITCH_CHANNEL = origChannel;
+
+        if (origBotToken === undefined) delete process.env.TWITCH_BOT_TOKEN;
+        else process.env.TWITCH_BOT_TOKEN = origBotToken;
+
+        if (origClientId === undefined) delete process.env.TWITCH_CLIENT_ID;
+        else process.env.TWITCH_CLIENT_ID = origClientId;
+
+        if (origClientSecret === undefined) delete process.env.TWITCH_CLIENT_SECRET;
+        else process.env.TWITCH_CLIENT_SECRET = origClientSecret;
+
         globalThis.fetch = originalFetch;
     });
 

--- a/src/twitch/bot.ts
+++ b/src/twitch/bot.ts
@@ -10,6 +10,7 @@ import {
     CommandRateLimiter,
     DEFAULT_COMMAND_RATE_LIMIT,
 } from './command-rate-limit.js';
+import { parseCommand as parseChatCommand } from './commands.js';
 
 export interface BotConfig {
     channel: string;
@@ -23,7 +24,7 @@ export interface ParsedCommand {
     action: 'press' | 'present' | 'vote' | 'sentence';
     username: string;
     timestamp: number;
-    params?: Record<string, any>;
+    params: Record<string, any>;
 }
 
 export interface RedemptionEvent {
@@ -123,19 +124,16 @@ export class TwitchBot {
         message: string,
         username: string,
     ): ParsedCommand | null {
-        // Check rate limit first
         const rateLimitCheck = this.commandRateLimiter.check(username, message);
         if (!rateLimitCheck.allowed) {
             console.warn(
-                `[Twitch Bot] Command rate limited for ${username}: ${rateLimitCheck.reason}`,
+                `[Twitch Bot] Rate limited ${username}: ${rateLimitCheck.reason}`,
             );
             return null;
         }
 
-        // Will delegate to commands.ts parser
-        // For now, stub
-        console.log(`[Twitch Bot] Parsed command from ${username}: ${message}`);
-        return null;
+        const parsed = parseChatCommand(message, username);
+        return parsed as ParsedCommand | null;
     }
 
     /**

--- a/src/twitch/bot.ts
+++ b/src/twitch/bot.ts
@@ -245,6 +245,7 @@ export class TwitchBot {
         this.isActive = false;
 
         if (this.tmiClient) {
+            this.tmiClient.removeAllListeners();
             await this.tmiClient.disconnect().catch(() => {});
             this.tmiClient = null;
         }

--- a/src/twitch/tmi.d.ts
+++ b/src/twitch/tmi.d.ts
@@ -1,3 +1,5 @@
+// tmi.js v1.8.5 ships no TypeScript declarations and @types/tmi.js is not available.
+// This minimal declaration provides the types needed by bot.ts.
 declare module 'tmi.js' {
     interface ChatUserstate {
         username?: string;
@@ -20,6 +22,7 @@ declare module 'tmi.js' {
         on(event: string, listener: (...args: unknown[]) => void): this;
         connect(): Promise<[string, number]>;
         disconnect(): Promise<[string, number]>;
+        removeAllListeners(event?: string): this;
     }
 
     const tmi: {

--- a/src/twitch/tmi.d.ts
+++ b/src/twitch/tmi.d.ts
@@ -1,0 +1,31 @@
+declare module 'tmi.js' {
+    interface ChatUserstate {
+        username?: string;
+        'display-name'?: string;
+        [key: string]: string | boolean | undefined;
+    }
+
+    interface Options {
+        identity?: {
+            username: string;
+            password: string;
+        };
+        channels?: string[];
+        options?: Record<string, unknown>;
+    }
+
+    class Client {
+        constructor(opts: Options);
+        on(event: 'message', listener: (channel: string, tags: ChatUserstate, message: string, self: boolean) => void): this;
+        on(event: string, listener: (...args: unknown[]) => void): this;
+        connect(): Promise<[string, number]>;
+        disconnect(): Promise<[string, number]>;
+    }
+
+    const tmi: {
+        Client: typeof Client;
+    };
+
+    export { Client, ChatUserstate, Options };
+    export default tmi;
+}


### PR DESCRIPTION
## Summary

- Wires `commands.ts` parser into `TwitchBot.parseCommand` (was a stub returning null) — adds `src/twitch/bot.test.ts` with 5 unit tests
- Implements real `connectIRC()` using tmi.js: creates `tmi.Client`, listens to chat messages, resolves active session ID per-message, and calls `forwardCommand`
- Adds `forwardCommand()` private method routing `!press` → `/press`, `!present` → `/present`, `!vote`/`!sentence` → `/vote` with correct body shapes
- Initialises the bot in `server.ts` startup (noop when env vars absent, logs "Twitch bot disabled: missing credentials")
- Adds `src/twitch/tmi.d.ts` minimal type declarations (tmi.js 1.8.5 ships no TS types)
- Adds 3 routing tests for `forwardCommand` path/body correctness using a mocked `globalThis.fetch`

## Test Plan

- [ ] `npm test` — 179 pass, 0 fail
- [ ] `npm run lint` passes
- [ ] Server starts without Twitch env vars → logs "Twitch bot disabled: missing credentials"
- [ ] With Twitch credentials set: server connects to IRC, `!press 2` in chat → `POST /api/court/sessions/:id/press`
- [ ] Check session metadata — `pressVotes` updates after `!press`

Closes #77

> Note: Orchestrator integration (reading pressVotes/presentVotes at decision points) is blocked by #76 and is out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)